### PR TITLE
исправлено дублирование POST запроса при выборе пункта

### DIFF
--- a/api/libs/api.astral.php
+++ b/api/libs/api.astral.php
@@ -467,7 +467,7 @@ function wf_AjaxSelectorAC($container, $params, $label, $selected = '', $br = fa
     } else {
         $newline = '';
     }
-    $result = '<select name="' . $inputid . '" id="' . $inputid . '" onChange="this.options[this.selectedIndex].onclick();">';
+    $result = '<select name="' . $inputid . '" id="' . $inputid . '">';
     if (!empty($params)) {
         foreach ($params as $value => $eachparam) {
             $sel_flag = '';


### PR DESCRIPTION
Проблема обнаружилась, когда включил IP_CUSTOM_SELECT и зашел в редактирование IP клиента. И когда выбираешь пункт в выдпадающем списке "Выберите новую услугу пользователя", то отправляется два POST запроса. 
Данный pull request фиксит этот баг.
Возможно код биллинга был так написан для совместимости с разными браузерами.
Я тестировал на firefox, работает норм...