### PR TITLE
Added ability to use a percent-from-tariff-cost type of punishment

### DIFF
--- a/config/alter.ini
+++ b/config/alter.ini
@@ -397,6 +397,8 @@ CUD_CFID=""
 CAP_ENABLED=0
 ;Days limit to push penalty
 CAP_DAYLIMIT=30
+;Penalty percent
+CAP_PENALTY_PERCENT=0
 ;Penalty cash summ
 CAP_PENALTY=20
 ;Payment type for crime and punishment fees

--- a/config/optsaltcfg
+++ b/config/optsaltcfg
@@ -147,12 +147,12 @@ CHAPTEREND_DISCOUNT=true
 
 CHAPTER_DOSTOEVSKY=Dostoevsky
 CAP_ENABLED=TRIGGER|Crime and punishment enabled
+CAP_IGNOREFROZEN=TRIGGER|Do not call Raskolnikov frozen
+CAP_PAYID=VARCHAR|Payment type
 CAP_DAYLIMIT=VARCHAR|Days limit to push penalty
 CAP_PENALTY=VARCHAR|Penalty cash summ
-CAP_PAYID=VARCHAR|Payment type
-CAP_IGNOREFROZEN=TRIGGER|Do not call Raskolnikov frozen
+CAP_PENALTY_PERCENT=VARCHAR|Penalty percent from tariff's fee amount(takes precedence over penalty cash sum if grater than zero)
 CHAPTEREND_DOSTOEVSKY=true
-
 
 CHAPTER_DOCSIS=DOCSIS
 DOCSIS_SUPPORT=TRIGGER|Enable DOCSIS support

--- a/index.php
+++ b/index.php
@@ -92,6 +92,8 @@ if(!empty($menu_points)){
    	}
 }
 
+
+
 if (XHPROF) {
 $xhprof_data = xhprof_disable();
 $xhprof_runs = new XHProfRuns_Default();


### PR DESCRIPTION
Wen punishment fee is not a constant value, but is calculated like:
(CAP_PENALTY_PERCENT / 100) * TARIFF_FEE
individually for every subscriber. CAP_PENALTY_PERCENT is a new option in **alter.ini**.
Note, that CAP_PENALTY_PERCENT takes precedence over the CAP_PENALTY, if grater than 0.

Signed-off-by: bobr-kun <demon.bobr@gmail.com>