### PR TITLE
Added string parameter $DisabledTimeRanges to wf_TimePickerPreset() and wf_TimePickerPresetSeconds() functions of api.astral.php.

### DIFF
--- a/api/libs/api.astral.php
+++ b/api/libs/api.astral.php
@@ -1856,19 +1856,25 @@ function wf_AutocompleteTextInput($name, $data = array(), $label = '', $value = 
 
 /**
  * Returns calendar widget with preset time
- * 
+ * Based on Jon Thornton's jquery timepicker:   http://jonthornton.github.io/jquery-timepicker
+ *
  * @param string $field field name to insert time select widget
  * @param string $time default value time for widget
+ * @param string $DisabledTimeRanges string which represents time ranges unavailable to pick up, like: "['11:00', '14:05'], ['20:30', '21:00']" and so on
  * @param string $label label of widget
  * @param bool $br add break after the widget body?
  * @return string
  */
-function wf_TimePickerPreset($field, $time = '', $label = '', $br = false) {
+function wf_TimePickerPreset($field, $time = '', $DisabledTimeRanges = '', $label = '', $br = false) {
     $inputId = wf_InputId();
+
+    if (isset($DisabledTimeRanges)) {
+        $DisabledTimeRanges = ',\'disableTimeRanges\': [ ' . $DisabledTimeRanges . ']';
+    }
 
     $result = wf_tag('input', false, '', 'type="text" value="' . $time . '" name="' . $field . '" size="5" id="' . $inputId . '"');
     $result.= wf_tag('script');
-    $result.='$(\'#' . $inputId . '\').timepicker({\'scrollDefault\': \'' . $time . '\', \'timeFormat\': \'H:i\' });';
+    $result.='$(\'#' . $inputId . '\').timepicker({\'scrollDefault\': \'' . $time . '\', \'timeFormat\': \'H:i\'' . $DisabledTimeRanges . ' });';
     $result.= wf_tag('script', true);
 
     //clickable icon and label
@@ -1886,19 +1892,25 @@ function wf_TimePickerPreset($field, $time = '', $label = '', $br = false) {
 
 /**
  * Returns calendar widget with preset time
- * 
+ * Based on Jon Thornton's jquery timepicker:   http://jonthornton.github.io/jquery-timepicker
+ *
  * @param string $field field name to insert time select widget
  * @param string $time default value time for widget
+ * @param string $DisabledTimeRanges string which represents time ranges unavailable to pick up, like: "['11:00', '14:05'], ['20:30', '21:00']" and so on
  * @param string $label label of widget
  * @param bool $br add break after the widget body?
  * @return string
  */
-function wf_TimePickerPresetSeconds($field, $time = '', $label = '', $br = false) {
+function wf_TimePickerPresetSeconds($field, $time = '', $DisabledTimeRanges = '', $label = '', $br = false) {
     $inputId = wf_InputId();
+
+    if (isset($DisabledTimeRanges)) {
+        $DisabledTimeRanges = ',\'disableTimeRanges\': [ ' . $DisabledTimeRanges . ']';
+    }
 
     $result = wf_tag('input', false, '', 'type="text" value="' . $time . '" name="' . $field . '" size="8" id="' . $inputId . '"');
     $result.= wf_tag('script');
-    $result.='$(\'#' . $inputId . '\').timepicker({\'scrollDefault\': \'' . $time . '\', \'timeFormat\': \'H:i:s\' });';
+    $result.='$(\'#' . $inputId . '\').timepicker({\'scrollDefault\': \'' . $time . '\', \'timeFormat\': \'H:i:s\'' . $DisabledTimeRanges . ' });';
     $result.= wf_tag('script', true);
 
     //clickable icon and label

--- a/api/libs/api.dshaper.php
+++ b/api/libs/api.dshaper.php
@@ -135,8 +135,8 @@ class DynamicShaper {
         $sup = wf_tag('sup') . '*' . wf_tag('sup', true);
 
         $inputs = wf_Selector('newdshapetariff', $this->selectorParams, __('Tariff'), '', true);
-        $inputs.= wf_TimePickerPresetSeconds('newthreshold1', '', __('Time from') . $sup . ' ', true);
-        $inputs.= wf_TimePickerPresetSeconds('newthreshold2', '', __('Time to') . $sup . ' ', true);
+        $inputs.= wf_TimePickerPresetSeconds('newthreshold1', '', '', __('Time from') . $sup . ' ', true);
+        $inputs.= wf_TimePickerPresetSeconds('newthreshold2', '', '', __('Time to') . $sup . ' ', true);
         $inputs.= wf_TextInput('newspeed', __('Speed') . $sup, '', true, 8);
         $inputs.= wf_Submit(__('Create'));
         $result = wf_Form('', 'POST', $inputs, 'glamour');
@@ -162,8 +162,8 @@ class DynamicShaper {
         $inputs.= wf_tag('select', true);
         $inputs.= wf_tag('br');
         $inputs.= wf_HiddenInput('editdshapetariff', $timerule_data['tariff']);
-        $inputs.= wf_TimePickerPresetSeconds('editthreshold1', $timerule_data['threshold1'], __('Time from') . $sup, true);
-        $inputs.= wf_TimePickerPresetSeconds('editthreshold2', $timerule_data['threshold2'], __('Time to') . $sup, true);
+        $inputs.= wf_TimePickerPresetSeconds('editthreshold1', $timerule_data['threshold1'], '', __('Time from') . $sup, true);
+        $inputs.= wf_TimePickerPresetSeconds('editthreshold2', $timerule_data['threshold2'], '', __('Time to') . $sup, true);
         $inputs.= wf_TextInput('editspeed', __('Speed') . $sup, $timerule_data['speed'], true, 8);
         $inputs.= wf_Submit(__('Save'));
         $form = wf_Form('', 'POST', $inputs, 'glamour');

--- a/api/libs/api.stickynotes.php
+++ b/api/libs/api.stickynotes.php
@@ -252,7 +252,7 @@ class StickyNotes {
         $inputs.= wf_DatePickerPreset('newreminddate', '');
         $inputs.= wf_tag('label') . __('Remind only after this date') . wf_tag('label', true);
         $inputs.=wf_tag('br');
-        $inputs.= wf_TimePickerPreset('newremindtime', '', __('Remind time'), false);
+        $inputs.= wf_TimePickerPreset('newremindtime', '', '', __('Remind time'), false);
         $inputs.= wf_tag('br');
         $inputs.= wf_tag('br');
         $inputs.= wf_Submit(__('Create'));
@@ -278,7 +278,7 @@ class StickyNotes {
             $inputs.= wf_DatePickerPreset('editreminddate', $noteData['reminddate']);
             $inputs.= wf_tag('label') . __('Remind only after this date') . wf_tag('label', true);
             $inputs.= wf_tag('br');
-            $inputs.= wf_TimePickerPreset('editremindtime', $noteData['remindtime'], __('Remind time'), true);
+            $inputs.= wf_TimePickerPreset('editremindtime', $noteData['remindtime'], '', __('Remind time'), true);
             $inputs.= wf_tag('br');
             $inputs.= wf_tag('br');
             $inputs.= wf_Submit(__('Save'));

--- a/api/libs/api.teskman.php
+++ b/api/libs/api.teskman.php
@@ -1356,6 +1356,7 @@ function ts_TaskModifyForm($taskid) {
         } else {
             $inputs.=wf_HiddenInput('modifystartdate', $taskdata['startdate']);
         }
+
         $inputs.=wf_TimePickerPreset('modifystarttime', $taskdata['starttime'], '', false);
         $inputs.=wf_tag('label') . __('Target date') . wf_tag('sup') . '*' . wf_tag('sup', true) . wf_tag('label', true);
         $inputs.=wf_delimiter();


### PR DESCRIPTION
It represents time ranges which are unavailable to pick up, like: "['11:00', '14:05'], ['20:30', '21:00']" and so on. Usages of modified wf_TimePickerPreset() function in api.stikynotes.php, api.teskman.php and modified wf_TimePickerPresetSeconds() function in api.dshaper.php have been refactored to macth new wf_TimePickerPreset and wf_TimePickerPresetSeconds signatures(new parameter and parameters order).

Исправил параметры и их порядок и трижды(!) перепроверил все найденные использования функций wf_TimePickerPreset() и wf_TimePickerPresetSeconds() аж в 3-х файлах: api.stikynotes.php, api.teskman.php и api.dshaper.php.
Проверил на тестовом сервере: динамические шейперы, планировщик задач, персональные заметки - все работают, таймпикеры в них тоже. Больше использования таймпикеров нигде не обнаружил. 
З.Ы. должно бы влиться без каких-либо проблем...  