### PR TITLE
Asterisk - добавлена поддержка Remote API

### DIFF
--- a/api/libs/api.asterisk.php
+++ b/api/libs/api.asterisk.php
@@ -394,19 +394,20 @@ class Asterisk {
      * @return void
      */
     public function AsteriskGetInfoApi($number, $param) {
-		$this->AsteriskGetLoginByNumberQuery();
-		$number_cut = substr($number, -10);
-		$login = @$this->result_NumberLogin[$number_cut];
-		if (!empty($login)) {
-			if ($param == "login") {
-				$result = $login;
-			}
-			if ($param == "swstatus") {
-				$result = $this->AsteriskGetSWStatus($login);
-			}
-		} else {
-			$result = 'ERROR: NOT OUR USER';
-		}
+        $this->AsteriskGetLoginByNumberQuery();
+        $number_cut = substr($number, -10);
+        $login = @$this->result_NumberLogin[$number_cut];
+        if (!empty($login)) {
+            if ($param == "login") {
+                $result = $login;
+            } elseif ($param == "swstatus") {
+                $result = $this->AsteriskGetSWStatus($login);
+            } else {
+                $result = 'ERROR: MISTAKE PARAMETR';
+            }
+        } else {
+            $result = 'ERROR: NOT OUR USER';
+        }
         return ($result);
     }
 

--- a/api/libs/api.asterisk.php
+++ b/api/libs/api.asterisk.php
@@ -368,6 +368,49 @@ class Asterisk {
     }
 
     /**
+     * Get status switch for user
+     *
+     * @param int $login - user login
+     *
+     * @return string
+     */
+    protected function AsteriskGetSWStatus($login) {
+        $alldeadswitches = zb_SwitchesGetAllDead();
+        $query = "SELECT `login`,`ip` FROM `switchportassign` LEFT JOIN `switches` ON switchportassign.switchid=switches.id WHERE `login`='" . $login . "';";
+        $result_q = simple_query($query);
+        if (empty($result_q) ) {
+            $result =  'ERROR: USER NOT HAVE SWITCH';
+        } else {
+            $result = isset($alldeadswitches[$result_q['ip']]) ? "DEAD" : "OK";
+        }
+        return ($result);
+    }
+
+    /**
+     * Get status switch and other for user, if his bumber have database. Use only in remote API.
+     * 
+     * @param int $number, $param
+     * 
+     * @return void
+     */
+    public function AsteriskGetInfoApi($number, $param) {
+		$this->AsteriskGetLoginByNumberQuery();
+		$number_cut = substr($number, -10);
+		$login = @$this->result_NumberLogin[$number_cut];
+		if (!empty($login)) {
+			if ($param == "login") {
+				$result = $login;
+			}
+			if ($param == "swstatus") {
+				$result = $this->AsteriskGetSWStatus($login);
+			}
+		} else {
+			$result = 'ERROR: NOT OUR USER';
+		}
+        return ($result);
+    }
+
+    /**
      * Converts per second time values to human-readable format
      * 
      * @param int $seconds - time interval in seconds

--- a/modules/general/remoteapi/index.php
+++ b/modules/general/remoteapi/index.php
@@ -754,6 +754,32 @@ if ($alterconf['REMOTEAPI_ENABLED']) {
                         }
                     }
 
+                    /*
+                     * Ubilling remote API for Asterisk and other CRM
+                     * -----------------------------
+                     * 
+                     * Format: /?module=remoteapi&key=[ubserial]&action=[action]&number=[+380XXXXXXXXX]&param=[parameter]
+                     * 
+                     * Avaible parameter: login, swstatus
+                     * 
+                     */
+                    if ($_GET['action'] == 'asterisk') {
+                        if ($alterconf['ASTERISK_ENABLED']) {
+                            if (wf_CheckGet(array('number'))) {
+                                if (wf_CheckGet(array('param'))) {
+                                    $asterisk = new Asterisk();
+                                    $result = $asterisk->AsteriskGetInfoApi($_GET['number'], $_GET['param']);
+                                    die($result);
+                                } else {
+                                    die('ERROR: NOT HAVE PARAMETR');
+                                }
+                            } else {
+                                die('ERROR: NOT HAVE NUMBER');
+                            }
+                        } else {
+                            die('ERROR: ASTERISK DISABLED');
+                        }
+                    }
 
 
                     ////


### PR DESCRIPTION
В **API Asterisk** добавлена функция вызова удаленного API через **[RemoteAPI](http://wiki.ubilling.net.ua/doku.php?id=remoteapi)** .

### Формат передачи данных (строго-все параметры обязательны):
`/?module=remoteapi&key=[ubserial]&action=[action]&number=[+380XXXXXXXXX]&param=[parameter]`

### Вызов API Asterisk **`[action]`** : 

- **`asterisk`**

### Обязательные параметры: 

-  **`&number=[+380XXXXXXXXX]`** - передача API номера звонящего в формате:
      -  **+380XXXXXXXXX** 
       -  **0XXXXXXXXX**
-  **`&param=[parameter]`** - какое действие выполнить в результате переданного параметра
     #### Доступные действия **`[parameter]`**: 
      -  **`login`** - позволяет получить логин клиента по номеру телефона;
      -  **`swstatus`** - позволяет получить состояние оборудования к которому привязан клиент в билинге по номеру телефона (Ответ будет: **`OK`** или **`DIE`**)
