### PR TITLE
Mikrotik firewall processing updated 

### DIFF
--- a/docs/presets/MikroTik/config.ini
+++ b/docs/presets/MikroTik/config.ini
@@ -23,3 +23,4 @@ rate_val = 'k'
 attempts = 3
 timeout = 2
 delay = 1
+use2addrlists = FALSE

--- a/docs/presets/MikroTik/system/executer/mikrotik.drv
+++ b/docs/presets/MikroTik/system/executer/mikrotik.drv
@@ -236,8 +236,15 @@
                     case 'OnConnect':
                     case 'OnDisconnect':
                         // Load template:
-                        $template = parse_ini_file(NASPATH . 'tpls/firewall.ini');
-                        $template['disabled'] = ( ENVIRONMENT != 'OnConnect' ) ? 'yes' : 'no';
+                        if ( $this->config['use2addrlists'] ) {
+                            $firewall_ini_path = ( ENVIRONMENT == 'OnConnect' ) ? 'firewall.ini' : 'firewall_off.ini';
+                            $template = parse_ini_file(NASPATH . 'tpls/' . $firewall_ini_path);
+                            $template['disabled'] = 'no';
+                        } else {
+                            $template = parse_ini_file(NASPATH . 'tpls/firewall.ini');
+                            $template['disabled'] = ( ENVIRONMENT != 'OnConnect' ) ? 'yes' : 'no';
+                        }
+
                     case 'OnChange':
                     case 'OnUserDel':
                     // Find entry on NAS:

--- a/docs/presets/MikroTik/system/executer/tpls/firewall_off.ini
+++ b/docs/presets/MikroTik/system/executer/tpls/firewall_off.ini
@@ -1,0 +1,4 @@
+list     = "NOT_ALLOW"
+address  = IP
+disabled = NULL
+comment  = LOGIN


### PR DESCRIPTION
Added firewall_off.ini file to/ docs/presets/MikroTik/system/executer/tpls/, added use2addrlists option to /docs/presets/MikroTik/config.ini. Now, if you want to use 2 types of address lists, like ALLOW and NOT_ALLOW(names are customizable) to move disconnected subscribers to another list instead of using one ALLOW list and disabling records in that ALLOW list, you need to make use2addrlists = TRUE.

Signed-off-by: bobr-kun <demon.bobr@gmail.com>