### PR TITLE
Mikrotik burst - fix problem when have reassigned speed

### DIFF
--- a/docs/presets/MikroTik/system/database/mysql.drv
+++ b/docs/presets/MikroTik/system/database/mysql.drv
@@ -98,7 +98,7 @@
         }
 
         private function get_user_reassigned_rate() {
-            $return = array('tx' => 0, 'rx' => 0);
+            $return = array('tx' => 0, 'rx' => 0, 'bt_tx' => 0, 'bt_rx' => 0, 'bt_tx_t' => 0, 'bt_rx_t' => 0);
             $result = $this->select('speed', 'userspeeds', array('login' => LOGIN));
             foreach ( $result as $data ) {
                 if ( !empty($data['speed']) ) {


### PR DESCRIPTION
Честно говоря, пропустили один коммит, когда исходники были еще на **Subversion**.
Проверил с исходным патчем-вроде все теперь внесено.
Проблема возникает только у пользователя, у которого есть переназначение скорости. В логи вылазит такая ошибка:
`2017-07-09 20:15:25 - [Executer] - Error: Queue entry can't be updated, invalid value  for upload-burst-limit, an integer required`.

Ну и на всякий случай исходный патч от **08-02-2016**:

```
diff -Naur MikroTik/system/database/mysql.drv stargazer/system/database/mysql.drv
--- MikroTik/system/database/mysql.drv	2016-04-26 14:25:15.000000000 +0300
+++ stargazer/system/database/mysql.drv	2016-08-02 14:20:54.000000000 +0300
@@ -78,7 +78,7 @@
         }
 
         private function get_user_reassigned_rate() {
-            $return = array('tx' => 0, 'rx' => 0);
+            $return = array('tx' => 0, 'rx' => 0, 'bt_tx' => 0, 'bt_rx' => 0, 'bt_tx_t' => 0, 'bt_rx_t' => 0);
             $result = $this->select('speed', 'userspeeds', array('login' => LOGIN));
             foreach ( $result as $data ) {
                 if ( !empty($data['speed']) ) {
@@ -91,8 +91,8 @@
         }
 
         private function get_tariff_rate($tariff) {
-            $return = array('tx' => 0, 'rx' => 0);
-            $result = $this->select('speedup, speeddown', 'speeds', array('tariff' => $tariff));
+            $return = array('tx' => 0, 'rx' => 0, 'bt_tx' => 0, 'bt_rx' => 0, 'bt_tx_t' => 0, 'bt_rx_t' => 0);
+            $result = $this->select('speedup, speeddown, burstupload, burstdownload, burstimetupload, bursttimedownload' , 'speeds', array('tariff' => $tariff));
             foreach ($result as $data) {
                 if ( !empty($data['speedup']) ) {
                     $return['tx'] = $data['speedup'];
@@ -102,6 +102,22 @@
                     $return['rx'] = $data['speeddown'];
                     $this->log->message(__CLASS__, "User's tariff RX rate - `" . $data['speeddown'] . "`", 'debug');
                 } else $this->log->message(__CLASS__, "User's tariff has no RX rate limit!", 'error');
+				if ( !empty($data['burstupload']) ) {
+                    $return['bt_tx'] = $data['burstupload'];
+                    $this->log->message(__CLASS__, "User's tariff Burst TX rate - `" . $data['burstupload'] . "`", 'debug');
+                };
+				if ( !empty($data['burstdownload']) ) {
+                    $return['bt_rx'] = $data['burstdownload'];
+                    $this->log->message(__CLASS__, "User's tariff Burst RX rate - `" . $data['burstdownload'] . "`", 'debug');
+                };
+				if ( !empty($data['burstimetupload']) ) {
+                    $return['bt_tx_t'] = $data['burstimetupload'];
+                    $this->log->message(__CLASS__, "User's tariff Burst Time TX rate - `" . $data['burstimetupload'] . "`", 'debug');
+                };
+				if ( !empty($data['bursttimedownload']) ) {
+                    $return['bt_rx_t'] = $data['bursttimedownload'];
+                    $this->log->message(__CLASS__, "User's tariff Burst Time RX rate - `" . $data['bursttimedownload'] . "`", 'debug');
+                };
             }
             return $return;
         }
diff -Naur MikroTik/system/executer/mikrotik.drv stargazer/system/executer/mikrotik.drv
--- MikroTik/system/executer/mikrotik.drv	2016-04-27 15:18:23.000000000 +0300
+++ stargazer/system/executer/mikrotik.drv	2016-08-02 12:13:43.000000000 +0300
@@ -315,6 +315,9 @@
                         $rate = $this->database->get_user_rate();
                         $template['limit-at']  = $rate['tx'] . $this->config['rate_val'] . '/' . $rate['rx'] . $this->config['rate_val'];
                         $template['max-limit'] = $rate['tx'] . $this->config['rate_val'] . '/' . $rate['rx'] . $this->config['rate_val'];
+                        $template['burst-limit'] = $rate['bt_tx'] . $this->config['rate_val'] . '/' . $rate['bt_rx'] . $this->config['rate_val'];
+                        $template['burst-time'] = $rate['bt_tx_t'] . '/' . $rate['bt_rx_t'];
+                        $template['burst-threshold'] =  $rate['tx']*0.8 . $this->config['rate_val'] . '/' . $rate['rx']*0.8 . $this->config['rate_val'];
                         if ($this->options['version'] == 4 || $this->options['version'] == 5) {
                             $template['interface'] = $this->options['users_interface'];
                         }

```