### PR TITLE
Модуль обновлений - изменена обработка SQL дампов

### DIFF
--- a/api/libs/api.dbconnect.php
+++ b/api/libs/api.dbconnect.php
@@ -63,7 +63,7 @@ class DbConnect {
             if (extension_loaded('mysql')) {
                 return (mysql_error());
            } else {
-               return ($this->conn->connect_error);
+               return ($this->conn->error);
            }
         }
     }

--- a/api/libs/api.updates.php
+++ b/api/libs/api.updates.php
@@ -60,6 +60,7 @@ class UbillingUpdateManager {
         $this->setConfigFilenames();
         $this->loadDumps();
         $this->loadConfigs();
+        $this->ConnectDB();
     }
 
     /**
@@ -130,6 +131,17 @@ class UbillingUpdateManager {
     }
 
     /**
+     * Initialises connection with Ubilling database server and selects needed db
+     *
+     * @param MySQL Connection Id $connection
+     * 
+     * @return MySQLDB
+     */
+    protected function ConnectDB() {
+        $this->DBConnection = new DbConnect($this->mySqlCfg['server'], $this->mySqlCfg['username'], $this->mySqlCfg['password'], $this->mySqlCfg['db'], true);
+    }
+
+    /**
      * Returns list of files which was updated in some release
      * 
      * @param string $release
@@ -146,6 +158,40 @@ class UbillingUpdateManager {
                 }
             }
         }
+        return($result);
+    }
+
+    /**
+     * Apply Mysql Dump and returns results
+     * 
+     * @param string $release
+     * 
+     * @return string
+     */
+    protected function DoSqlDump($release) {
+        $result = '';
+            if (!empty($release)) {
+                $fileName = self::DUMPS_PATH . $this->allDumps[$release];
+                $file = explode(';', file_get_contents($fileName));
+                $sql_dumps = array_diff($file, array(''));  // Delete empty data Array
+                $sql_array = array_map('trim', $sql_dumps);
+
+                // Open DB connection and set character 
+                $this->DBConnection->open();
+                $this->DBConnection->query("set character_set_client='" . $this->mySqlCfg['character'] . "'");
+                $this->DBConnection->query("set character_set_results='" . $this->mySqlCfg['character'] . "'");
+                $this->DBConnection->query("set collation_connection='" . $this->mySqlCfg['character'] . "_general_ci'");
+                
+                foreach ($sql_array as $query) {
+                    $this->DBConnection->query($query);
+                    if (! $this->DBConnection->error()) {
+                        $result .= $this->messages->getStyledMessage(wf_tag('b', false) . __('DONE: ') . wf_tag('b', true) . wf_tag('pre', false) . $query . wf_tag('pre', true),'success') . wf_tag('br');
+                    } else {
+                        $result .= $this->messages->getStyledMessage(wf_tag('b', false) . __('EROOR: ') . wf_tag('b', true) . $this->DBConnection->error() . wf_tag('pre', false) . $query . wf_tag('pre', true), 'error') . wf_tag('br');
+                    }
+                }
+                $this->DBConnection->close();
+            }
         return($result);
     }
 
@@ -225,11 +271,9 @@ class UbillingUpdateManager {
         $release = vf($release);
         if (isset($this->allDumps[$release])) {
             if (wf_CheckPost(array('applyconfirm', 'applysqldump'))) {
-                $fileName = self::DUMPS_PATH . $this->allDumps[$release];
-                $applyCommand = $this->altCfg['MYSQL_PATH'] . ' -u ' . $this->mySqlCfg['username'] . ' -p' . $this->mySqlCfg['password'] . ' -h' . $this->mySqlCfg['server'] . ' ' . $this->mySqlCfg['db'] . ' --default-character-set=utf8 < ' . $fileName . ' 2>&1; echo $?';
                 $result .= $this->messages->getStyledMessage(__('MySQL dump applying result below'), 'info');
                 $result .= wf_CleanDiv();
-                $result .= wf_tag('pre', false, '', 'style="width:100%;overflow:auto"') . shell_exec($applyCommand) . wf_tag('pre', true);
+                $result .= $this->DoSqlDump($release);
                 $result .= wf_BackLink(self::URL_ME);
                 log_register('UPDMGR APPLY SQL RELEASE `' . $release . '`');
             } else {

--- a/content/updates/sql/0.8.4.sql
+++ b/content/updates/sql/0.8.4.sql
@@ -2,4 +2,4 @@ ALTER TABLE `switches` ADD `snmpwrite` VARCHAR(45) NULL AFTER `swid`;
 
 ALTER TABLE `phones` ADD INDEX (`login`);
 
-ALTER TABLE `stg`.`print_card` ADD UNIQUE (`title`);
+ALTER TABLE `print_card` ADD UNIQUE (`title`);

--- a/content/updates/sql/0.8.4.sql
+++ b/content/updates/sql/0.8.4.sql
@@ -1,2 +1,5 @@
 ALTER TABLE `switches` ADD `snmpwrite` VARCHAR(45) NULL AFTER `swid`;
+
 ALTER TABLE `phones` ADD INDEX (`login`);
+
+ALTER TABLE `stg`.`print_card` ADD UNIQUE (`title`);

--- a/docs/test_dump.sql
+++ b/docs/test_dump.sql
@@ -1882,4 +1882,7 @@ CREATE TABLE IF NOT EXISTS `admacquainted` (
 
 -- 0.8.4
 ALTER TABLE `switches` ADD `snmpwrite` VARCHAR(45) NULL AFTER `swid`;
+
 ALTER TABLE `phones` ADD INDEX (`login`);
+
+ALTER TABLE `stg`.`print_card` ADD UNIQUE (`title`);

--- a/docs/test_dump.sql
+++ b/docs/test_dump.sql
@@ -1885,4 +1885,4 @@ ALTER TABLE `switches` ADD `snmpwrite` VARCHAR(45) NULL AFTER `swid`;
 
 ALTER TABLE `phones` ADD INDEX (`login`);
 
-ALTER TABLE `stg`.`print_card` ADD UNIQUE (`title`);
+ALTER TABLE `print_card` ADD UNIQUE (`title`);


### PR DESCRIPTION
1. Исправлена функция вывода ошибок при не верном SQL-запросу в классе **`DbConnect`**.
2. Утилита `mysqldump` - заменена на `PHP`.
3. Сделан вывод результатов применения дампов базы.

Есть пока несколько небольших косякав, но скорее они на долгосрочную перспективу, так-как все прекрасно работает и косяки могут возникнуть только из-за человеческого фактора.

Косяки вылазят только при повтором **применении обновления базы**

- создаются дубликаты индексов (на работу не влияют)
- выводит удачный результат создания таблицы из-за: `IF NOT EXISTS`

Так сейчас выгладит:
![default](https://user-images.githubusercontent.com/11805503/28990872-3a5f1870-798a-11e7-9e7a-bf89ec209223.png)
