### PR TITLE
New feature for creating exclusive DB lock.

### DIFF
--- a/api/libs/api.ipchange.php
+++ b/api/libs/api.ipchange.php
@@ -58,6 +58,13 @@ class IpChange {
      */
     protected $messages = '';
 
+    /**
+     * is database locking feature enabled
+     * 
+     * @var bool
+     */
+    protected $dbLockEnabled = false;
+
     const URL_ME = '?module=pl_ipchange';
 
     public function __construct() {
@@ -81,6 +88,9 @@ class IpChange {
             if ($this->altCfg['IP_CUSTOM_SELECT']) {
                 $this->customFlag = true;
             }
+        }
+        if (isset($this->altCfg['DB_LOCK_ENABLED'])) {
+            $this->dbLockEnabled = $this->altCfg['DB_LOCK_ENABLED'];
         }
     }
 
@@ -159,11 +169,11 @@ class IpChange {
 
             $result = wf_AjaxLoader();
             $inputs = wf_AjaxSelectorAC('ajcontainer', $servSelector, __('Select User new service'), '', false);
-            $inputs.= wf_tag('br') . wf_tag('br');
-            $inputs.= wf_AjaxContainer('ajcontainer', '', $this->ajIpSelector($defaultService));
-            $inputs.= wf_delimiter();
-            $inputs.= wf_Submit(__('Save'));
-            $result.= wf_Form("", 'POST', $inputs, 'floatpanels');
+            $inputs .= wf_tag('br') . wf_tag('br');
+            $inputs .= wf_AjaxContainer('ajcontainer', '', $this->ajIpSelector($defaultService));
+            $inputs .= wf_delimiter();
+            $inputs .= wf_Submit(__('Save'));
+            $result .= wf_Form("", 'POST', $inputs, 'floatpanels');
         } else {
             $result = $this->messages->getStyledMessage(__('No available services'), 'error');
         }
@@ -187,7 +197,7 @@ class IpChange {
                 @$nextFreeIp = multinet_get_next_freeip('nethosts', 'ip', $networkId);
                 if (!empty($nextFreeIp)) {
                     $result = wf_HiddenInput('ipselector', $nextFreeIp) . ' ' . $nextFreeIp . ' (' . __('first free for this service') . ')';
-                    $result.= wf_HiddenInput('serviceselector', $serviceId);
+                    $result .= wf_HiddenInput('serviceselector', $serviceId);
                 } else {
                     $result = __('No free IP available in selected pool. Please fix it in networks and services module.');
                 }
@@ -200,7 +210,7 @@ class IpChange {
                         $allFreeIpsSelector[$each] = $each;
                     }
                     $result = wf_Selector('ipselector', $allFreeIpsSelector, '', '', true);
-                    $result.= wf_HiddenInput('serviceselector', $serviceId);
+                    $result .= wf_HiddenInput('serviceselector', $serviceId);
                 } else {
                     $result = __('No free IP available in selected pool. Please fix it in networks and services module.');
                 }
@@ -217,7 +227,7 @@ class IpChange {
     public function renderCurrentIp() {
         $result = wf_tag('h2', false, 'floatpanels', '') . ' ' . $this->currentIp . wf_tag('h2', true);
         $result = $this->messages->getStyledMessage(wf_tag('h2', false, '', '') . __('Current user IP') . ': ' . $this->currentIp . wf_tag('h2', true), 'info');
-        $result.= wf_CleanDiv();
+        $result .= wf_CleanDiv();
         return ($result);
     }
 
@@ -282,11 +292,11 @@ class IpChange {
         $data = $this->getFreeIpStats();
 
         $cells = wf_TableCell(__('ID'));
-        $cells.= wf_TableCell(__('Network/CIDR'));
-        $cells.= wf_TableCell(__('Total') . ' ' . __('IP'));
-        $cells.= wf_TableCell(__('Used') . ' ' . __('IP'));
-        $cells.= wf_TableCell(__('Free') . ' ' . __('IP'));
-        $cells.= wf_TableCell(__('Service'));
+        $cells .= wf_TableCell(__('Network/CIDR'));
+        $cells .= wf_TableCell(__('Total') . ' ' . __('IP'));
+        $cells .= wf_TableCell(__('Used') . ' ' . __('IP'));
+        $cells .= wf_TableCell(__('Free') . ' ' . __('IP'));
+        $cells .= wf_TableCell(__('Service'));
         $rows = wf_TableRow($cells, 'row1');
 
         if (!empty($data)) {
@@ -294,12 +304,12 @@ class IpChange {
                 $free = $each['total'] - $each['used'];
                 $fontColor = ($free <= 5) ? '#a90000' : '';
                 $cells = wf_TableCell($io);
-                $cells.= wf_TableCell($each['desc']);
-                $cells.= wf_TableCell($each['total']);
-                $cells.= wf_TableCell($each['used']);
-                $cells.= wf_TableCell(wf_tag('font', false, '', 'color="' . $fontColor . '"') . $free . wf_tag('font', false));
-                $cells.= wf_TableCell($each['service']);
-                $rows.= wf_TableRow($cells, 'row3');
+                $cells .= wf_TableCell($each['desc']);
+                $cells .= wf_TableCell($each['total']);
+                $cells .= wf_TableCell($each['used']);
+                $cells .= wf_TableCell(wf_tag('font', false, '', 'color="' . $fontColor . '"') . $free . wf_tag('font', false));
+                $cells .= wf_TableCell($each['service']);
+                $rows .= wf_TableRow($cells, 'row3');
             }
         }
 
@@ -332,6 +342,15 @@ class IpChange {
      * @return void/string
      */
     public function changeUserIp($serviceId, $newIp) {
+        //set lock or wait until previous lock will be released
+        //lock name "ipBind" is shared between userreg and pl_ipchange
+        if($this->dbLockEnabled) {
+            $dbLockQuery = 'SELECT GET_LOCK("ipBind",1)';
+            $dbLock = false;
+            while(!$dbLock) {
+                $dbLock = simple_query($dbLockQuery);
+            }
+        }
         global $billing;
         $result = '';
         $serviceId = vf($serviceId, 3);
@@ -377,6 +396,11 @@ class IpChange {
         } else {
             log_register("CHANGE FAIL MultiNetIP (" . $this->login . ") FROM " . $this->currentIp . " ON " . $newIp . " NO_SERVICE");
             $result = __('Unexistent service');
+        }
+        //release lock
+        if($this->dbLockEnabled) {
+            $dbUnlockQuery = 'SELECT RELEASE_LOCK("ipBind")';
+            nr_query($dbUnlockQuery);
         }
         return ($result);
     }

--- a/config/alter.ini
+++ b/config/alter.ini
@@ -558,3 +558,5 @@ JUNGEN_ENABLED=0
 EASY_SMS=0
 ;Is NAS monitoring enabled?
 NASMON_ENABLED=0
+;Is exclusive database lock is enabled (new user/change ip)?
+;DB_LOCK_ENABLED=0

--- a/modules/general/userreg/index.php
+++ b/modules/general/userreg/index.php
@@ -2,6 +2,13 @@
 
 if (cfr('USERREG')) {
     $alter_conf = $ubillingConfig->getAlter();
+    //check if exclusive database locking is enabled
+    $dbLockEnabled = false;
+    if (isset($alter_conf['DB_LOCK_ENABLED'])) {
+        if ($alter_conf['DB_LOCK_ENABLED']) {
+            $dbLockEnabled = true;
+        }
+    }
     if ((!isset($_POST['apt'])) AND ( !isset($_POST['IP']))) {
         show_window(__('User registration step 1 (location)'), web_UserRegFormLocation());
     } else {
@@ -24,6 +31,15 @@ if (cfr('USERREG')) {
             $newuser_data = unserialize(base64_decode($_POST['repostdata']));
         }
 
+        //create exclusive lock or wait until previous lock will be released
+        //lock name "ipBind" is shared between userreg and pl_ipchange
+        if ($dbLockEnabled) {
+            $dbLockQuery = 'SELECT GET_LOCK("ipBind",1)';
+            $dbLock = false;
+            while (!$dbLock) {
+                $dbLock = simple_query($dbLockQuery);
+            }
+        }
         show_window(__('User registration step 2 (Services)'), web_UserRegFormNetData($newuser_data));
         zb_BillingStats(true);
 
@@ -32,6 +48,11 @@ if (cfr('USERREG')) {
             $newuser_data['login'] = $_POST['login'];
             $newuser_data['password'] = $_POST['password'];
             zb_UserRegister($newuser_data);
+            //release db lock
+            if ($dbLockEnabled) {
+                $dbUnlockQuery = 'SELECT RELEASE_LOCK("ipBind")';
+                nr_query($dbUnlockQuery);
+            }
         }
     }
 


### PR DESCRIPTION
Creating lock in database when changing IP or registering new user to avoid problem with inconsistent data in nethosts table.
Controlled by optional string DB_LOCK_ENABLED in alter.ini.

Need testing.
Adding "sleep 30" to OnConnect or OnDisconnect should be enough to reproduce problem.