### PR TITLE
update_userreg_with_translation

### DIFF
--- a/api/libs/api.pon.php
+++ b/api/libs/api.pon.php
@@ -153,6 +153,16 @@ class PONizer {
     }
 
     /**
+     * Getter for allOltDevices array
+     *
+     * @return array
+     */
+
+    public function getAllOltDevices() {
+        return $this->allOltDevices;
+    }
+
+    /**
      * Loads all available snmp models data into private data property
      * 
      * @return void
@@ -825,6 +835,39 @@ class PONizer {
     }
 
     /**
+     * Returns int for ONU has or has not some of subscribers login assignment
+     * 0 - has no assignment
+     * 1 - has assignment, but login does not exist
+     * 2 - has assignment
+     *
+     * @param int $onuid
+     *
+     * @return int
+     */
+    public function checkONUAssignment($onuid) {
+        $result = 0;
+        $tLogin = '';
+
+        if (empty($onuid)) return $result;
+
+        $query = "SELECT * from `pononu` WHERE `id`='" . $onuid . "'" ;
+        $all = simple_queryall($query);
+        if (!empty($all)) {
+            $tLogin = $all[0]['login'];
+
+            if (!empty($tLogin)) {
+                $query = "SELECT * from `users` WHERE `login`='" . $tLogin . "'" ;
+                $LoginRec = simple_queryall($query);
+
+                empty($LoginRec) ? $result = 1 : $result = 2;
+            }
+        }
+
+        return $result;
+    }
+
+
+    /**
      * Getter for loaded ONU devices
      * 
      * @return array
@@ -832,6 +875,29 @@ class PONizer {
     public function getAllOnu() {
         return ($this->allOnu);
     }
+
+    /**
+     * Returns ONU ID by ONU MAC or 0 if not found
+     *
+     * @param string $mac
+     *
+     * @return int
+     */
+    public function getONUIDByMAC($mac) {
+        $mac = strtolower($mac);
+        $ONUID = 0;
+
+        if (!empty($this->allOnu)) {
+            foreach ($this->allOnu as $io => $each) {
+                if ($each['mac'] == $mac) {
+                    $ONUID = $each['id'];
+                }
+            }
+        }
+
+        return $ONUID;
+    }
+
 
     /**
      * Loads available device models from database
@@ -845,6 +911,15 @@ class PONizer {
                 $this->allModelsData[$each['id']] = $each;
             }
         }
+    }
+
+    /**
+     * Getter for allModelsData array
+     *
+     * @return array
+     */
+    public function getAllModelsData() {
+        return $this->allModelsData;
     }
 
     /**
@@ -867,7 +942,7 @@ class PONizer {
      * @param string $mac
      * @return bool
      */
-    protected function checkMacUnique($mac) {
+    public function checkMacUnique($mac) {
         $mac = strtolower($mac);
         $result = true;
         if (!empty($this->allOnu)) {

--- a/api/libs/api.userreg.php
+++ b/api/libs/api.userreg.php
@@ -516,6 +516,97 @@ function web_UserRegFormNetData($newuser_data) {
         $form.= wf_tag('tr', true);
     }
 
+    $PONAPIObject = new PONizer();
+
+    $models = array();
+    $ModelsData = $PONAPIObject->getAllModelsData();
+    if (!empty($ModelsData)) {
+        foreach ($ModelsData as $io => $each) {
+            $models[$each['id']] = $each['modelname'];
+        }
+    }
+
+    $form.= wf_tag('tr', false, 'row3');
+    $form.= wf_tag('tr', true, 'row3');
+    $form.= wf_tag('tr', false, 'row3');
+    $form.= wf_tag('tr', true, 'row3');
+
+    $form.= wf_tag('tr', false, 'row3');
+    $form.= wf_tag('td', false, '', 'style="padding-left: 15px"');
+    $form.= wf_tag('h3', false, '', 'style="color: #000"');
+    $form.= __('Associate ONU with subscriber');
+    $form.= wf_tag('h3', true);
+    $form.= wf_tag('td', true);
+    $form.= wf_tag('td', false);
+    $form.= wf_tag('td', true);
+    $form.= wf_tag('tr', true);
+
+    $form.= wf_tag('tr', false, 'row3');
+    $form.= wf_tag('td', false);
+    $form.= wf_Selector('oltid', $PONAPIObject->getAllOltDevices(), '', '', true);
+    $form.= wf_tag('td', true);
+    $form.= wf_tag('td', false);
+    $form.= __('OLT device') . wf_tag('sup') . '*' . wf_tag('sup', true);
+    $form.= wf_tag('td', true);
+    $form.= wf_tag('tr', true);
+
+    $form.= wf_tag('tr', false, 'row3');
+    $form.= wf_tag('td', false);
+    $form.= wf_Selector('onumodelid', $models, '', '', true);
+    $form.= wf_tag('td', true);
+    $form.= wf_tag('td', false);
+    $form.= __('ONU model') . wf_tag('sup') . '*' . wf_tag('sup', true);
+    $form.= wf_tag('td', true);
+    $form.= wf_tag('tr', true);
+
+    $form.= wf_tag('tr', false, 'row3');
+    $form.= wf_tag('td', false);
+    $form.= wf_tag('input', false, '', 'type="text" name="onuip" value="" ');
+    $form.= wf_CheckInput('onuipproposal', __('Make ONU IP same as subscriber IP'), false, false);
+    $form.= wf_tag('td', true);
+    $form.= wf_tag('td', false);
+    $form.=__('IP ONU');
+    $form.= wf_tag('td', true);
+    $form.= wf_tag('tr', true);
+
+    $form.= wf_tag('tr', false, 'row3');
+    $form.= wf_tag('td', false);
+    $form.= wf_tag('input', false, '', 'type="text" name="onumac" value="" ');
+    $form.= wf_tag('td', true);
+    $form.= wf_tag('td', false);
+    $form.=__('MAC ONU') . wf_tag('sup') . '*' . wf_tag('sup', true);
+    $form.= wf_tag('td', true);
+    $form.= wf_tag('tr', true);
+
+    $form.= wf_tag('tr', false, 'row3');
+    $form.= wf_tag('td', false);
+    $form.= wf_tag('a', false,'ubButton','href="" class="ubButton" id="onuassignment1"');
+    $form.= __('Check if ONU is assigned to any login already');
+    $form.= wf_tag('a', true);
+    $form.= wf_tag('script', false, '', 'type="text/javascript"');
+    $form.= '$(\'#onuassignment1\').click(function(evt){
+                if ( typeof( $(\'input[name=onumac]\').val() ) === "string" && $(\'input[name=onumac]\').val().length > 0 ) {
+                    $.ajax({
+                        type: "GET",
+                        url: "?module=userreg",
+                        data: {action:\'checkONUAssignment\', onumac:$(\'input[name=onumac]\').val()},
+                        success: function(result) {
+                                    $(\'#onuassignment2\').text(result);
+                                 }
+                    });
+                } else {$(\'#onuassignment2\').text(\'\');}
+                
+                evt.preventDefault();
+                return false;                
+            });';
+    $form.= wf_tag('script', true);
+    $form.= wf_tag('td', true);
+    $form.= wf_tag('td', false);
+    $form.= wf_tag('p', false, '', 'id="onuassignment2" style="font-weight: 600; color: #000"');
+    $form.= wf_tag('p', true);
+    $form.= wf_tag('td', true);
+    $form.= wf_tag('tr', true);
+
     $form.=wf_tag('table', true);
     $form.= wf_HiddenInput('repostdata', base64_encode(serialize($newuser_data)));
     $form.= wf_Submit(__('Let register that user'));
@@ -600,6 +691,13 @@ function zb_UserRegister($user_data, $goprofile = true) {
     @$floor = $user_data['floor'];
     $apt = $user_data['apt'];
     $serviceid = $user_data['service'];
+
+    $OLTID = $user_data['oltid'];
+    $ONUModelID = $user_data['onumodelid'];
+    $ONUIP = $user_data['onuip'];
+    $ONUMAC = $user_data['onumac'];
+    $NeedONUAssignment = !empty($ONUMAC);
+
     $netid = multinet_get_service_networkid($serviceid);
     $busylogins = zb_AllBusyLogins();
     //check login lenght
@@ -658,6 +756,7 @@ function zb_UserRegister($user_data, $goprofile = true) {
     zb_UserCreateEmail($login, '');
     zb_UserCreateSpeedOverride($login, 0);
     zb_UserRegisterLog($login);
+
     // if random mac needed
     $billingconf = rcms_parse_ini_file(CONFIG_PATH . '/billing.ini');
     $alterconf = rcms_parse_ini_file(CONFIG_PATH . "alter.ini");
@@ -737,6 +836,17 @@ function zb_UserRegister($user_data, $goprofile = true) {
         }
     }
 
+    // ONU assign for newly created user
+    if ($NeedONUAssignment) {
+        $PONAPIObject = new PONizer();
+
+        if ($PONAPIObject->checkMacUnique($ONUMAC)) {
+            $PONAPIObject->onuCreate($ONUModelID, $OLTID, $ONUIP, $ONUMAC, '', $login);
+        } else {
+            $ONUID = $PONAPIObject->getONUIDByMAC($ONUMAC);
+            $PONAPIObject->onuAssign($ONUID, $login);
+        }
+    }
 
     ///////////////////////////////////
     if ($goprofile) {

--- a/languages/russian/billing.php
+++ b/languages/russian/billing.php
@@ -2633,8 +2633,12 @@ $lang['def']['right to view NAS servers state report'] = 'Право просм�
 $lang['def']['Show unfinished'] = 'Показывать незавершенные';
 $lang['def']['All networks'] = 'Все сети';
 $lang['def']['Userstats intro'] = 'Интро кабинета';
-$lang['def'][''] = '';
-$lang['def'][''] = '';
+$lang['def']['Associate ONU with subscriber'] = 'Ассоциировать ONU с пользователем';
+$lang['def']['Make ONU IP same as subscriber IP'] = 'Использовать IP пользователя так же и как IP ONU';
+$lang['def']['Check if ONU is assigned to any login already'] = 'Проверить, не ассоциирована ли ONU с другим пользователем';
+$lang['def']['ONU is not assigned'] = 'ONU еще не ассоциирована';
+$lang['def']['ONU is already assigned'] = 'ONU уже ассоциирована';
+$lang['def']['ONU is already assigned, but such login is not exists anymore'] = 'ONU уже ассоциирована, но пользователя с таким логином больше не существует';
 
 
 ?>

--- a/languages/ukrainian/billing.php
+++ b/languages/ukrainian/billing.php
@@ -2649,5 +2649,11 @@ $lang['def']['right to view NAS servers state report'] = 'Право перег�
 $lang['def']['Show unfinished'] = 'Показувати незавершені';
 $lang['def']['All networks'] = 'Всі мережі';
 $lang['def']['Userstats intro'] = 'Інтро кабінету';
+$lang['def']['Associate ONU with subscriber'] = 'Асоціювати ONU з користувачем';
+$lang['def']['Make ONU IP same as subscriber IP'] = 'Використати IP користувача як IP ONU';
+$lang['def']['Check if ONU is assigned to any login already'] = 'Перевірити, че не асоційована ONU з іншим користувачем';
+$lang['def']['ONU is not assigned'] = 'ONU ще не асоційовано';
+$lang['def']['ONU is already assigned'] = 'ONU вже асоційовано';
+$lang['def']['ONU is already assigned, but such login is not exists anymore'] = 'ONU вже асоційовано, але користувача з таким логіном більше не існує';
 
 ?>

--- a/modules/general/userreg/index.php
+++ b/modules/general/userreg/index.php
@@ -9,6 +9,30 @@ if (cfr('USERREG')) {
             $dbLockEnabled = true;
         }
     }
+
+    if ( $_GET['action'] = 'checkONUAssignment' and isset($_GET['onumac']) ) {
+        $PONAPIObject = new PONizer();
+        $ONUMAC = $_GET['onumac'];
+        $ONUAssignment = $PONAPIObject->checkONUAssignment($PONAPIObject->getONUIDByMAC($ONUMAC));
+
+        switch ($ONUAssignment) {
+            case 0:
+                $tString = __('ONU is not assigned');
+                break;
+
+            case 1:
+                $tString = __('ONU is already assigned, but such login is not exists anymore');
+                break;
+
+            case 2:
+                $tString = __('ONU is already assigned');
+                break;
+        }
+
+        echo $tString;
+        die();
+    }
+
     if ((!isset($_POST['apt'])) AND ( !isset($_POST['IP']))) {
         show_window(__('User registration step 1 (location)'), web_UserRegFormLocation());
     } else {
@@ -48,6 +72,11 @@ if (cfr('USERREG')) {
             $newuser_data['IP'] = $_POST['IP'];
             $newuser_data['login'] = $_POST['login'];
             $newuser_data['password'] = $_POST['password'];
+            $newuser_data['oltid'] = $_POST['oltid'];
+            $newuser_data['onumodelid'] = $_POST['onumodelid'];
+            $newuser_data['onuip'] = wf_CheckPost(array('onuipproposal')) ? $_POST['onuip'] : $_POST['IP'];
+            $newuser_data['onumac'] = $_POST['onumac'];
+
             zb_UserRegister($newuser_data);
             //release db lock
             if ($dbLockEnabled) {


### PR DESCRIPTION
One more time...we gonna pull request...
USEREG module step 2 update: now it's possible to assign an ONU device when registering a new user. There is no need anymore to register user, copying it's login to clipboard, then add ONU and pasting the copied login to assign it to the newly created user - you can do it the same time when creating a new user. You can even reassign the existing ONU to newly created user, so you should be careful with this feature. There is an ability to check the current assignment of the ONU for that. It has 3 possible types of messages: 1 - ONU is assigned already, 2 - ONU is not assigned already and 3 - ONU is assigned already, but the login it assigned to is not exists anymore, so you'll be able to know the ONU status before any actions that can not be undone.