### PR TITLE
Оптимизация системы кэширования

### DIFF
--- a/api/libs/api.asterisk.php
+++ b/api/libs/api.asterisk.php
@@ -62,6 +62,7 @@ class Asterisk {
         $this->AsteriskLoadConf();
         $this->AsteriskLoadNumAliases();
         $this->AsteriskConnectDB();
+        $this->initCache();
     }
 
     /**
@@ -81,6 +82,35 @@ class Asterisk {
      */
     protected function initMessages() {
         $this->messages = new UbillingMessageHelper();
+    }
+
+    /**
+     * Initalizes system cache object for further usage
+     * 
+     * @return void
+     */
+    protected function initCache() {
+        $this->cache = new UbillingCache();
+    }
+
+    /**
+     * Check for last cache data and if need clean
+     * 
+     * @return void
+     */
+    protected function AsterikCacheInfoClean($asteriskTable, $from, $to) {
+        if (!empty($from) and !empty($to)) {
+        $query = "select uniqueid from `" . $asteriskTable . "` where `calldate` BETWEEN '" . $from . " 00:00:00' AND '" . $to . " 23:59:59'  AND `lastapp`='dial' ORDER BY `calldate` DESC LIMIT 1";
+        $cacheName = $from . $to;
+        $cache_uniqueid_key = 'ASTERISK_UNI_' . $cacheName;
+        $last_db_uniqueid = $this->AsteriskQuery($query);
+        $last_cache_uniqueid = $this->cache->get($cache_uniqueid_key, $this->config['cachetime']);
+        // Если `uniqueid` не равен записи в кеше, то очищаем весь кеш
+        if (($uniqueid = $last_db_uniqueid['0']['uniqueid']) != $last_cache_uniqueid) {
+            $this->cache->delete('ASTERISK_CDR_' . $cacheName, $this->config['cachetime']);
+            $this->cache->set($cache_uniqueid_key, $uniqueid, $this->config['cachetime']);
+        }
+        }
     }
 
     /**
@@ -177,7 +207,7 @@ class Asterisk {
                 $result[] = $row;
             }
             mysqli_free_result($result_query);
-            $this->AsteriskDB->close();
+            //$this->AsteriskDB->close();
             return ($result);
         } else {
             $result = rcms_redirect(self::URL_ME . '&config=true');
@@ -715,7 +745,7 @@ class Asterisk {
         $to = mysql_real_escape_string($to);
         $asteriskTable = mysql_real_escape_string($this->config['table']);
 
-        //caching
+       /* //caching
         $cacheUpdate = true;
         $cacheName = $from . $to;
         $cacheName = md5($cacheName);
@@ -732,7 +762,7 @@ class Asterisk {
             }
         } else {
             $cacheUpdate = true;
-        }
+        }*/
 
         if (! empty($user_login)) {
             //fetch some data from Asterisk database
@@ -757,17 +787,27 @@ class Asterisk {
             }
             if (!empty($query)) {
                 $rawResult = $this->AsteriskQuery($query);
-                $cacheContent = serialize($rawResult);
+                //$cacheContent = serialize($rawResult);
             }
         } elseif (wf_CheckPost(array('countnum')) and ! isset($user_login)) {
             $query = "select *,count(`src`) as `countnum`  from `" . $asteriskTable . "` where `calldate` BETWEEN '" . $from . " 00:00:00' AND '" . $to . " 23:59:59' AND `lastapp`='dial' GROUP BY `src`";
             $rawResult = $this->AsteriskQuery($query);
-            $cacheContent = serialize($rawResult);
-        } elseif ($cacheUpdate and ! isset($user_login)) {
+            //$cacheContent = serialize($rawResult);
+        /*} elseif ($cacheUpdate and ! isset($user_login)) {
             $query = "select * from `" . $asteriskTable . "` where `calldate` BETWEEN '" . $from . " 00:00:00' AND '" . $to . " 23:59:59'  AND `lastapp`='dial' ORDER BY `calldate` DESC";
             $rawResult = $this->AsteriskQuery($query);
             $cacheContent = serialize($rawResult);
             file_put_contents($cacheName, $cacheContent);
+        }*/
+        } else {
+            // check if need clean cache 
+            $this->AsterikCacheInfoClean($asteriskTable, $from, $to);
+            $query = "select * from `" . $asteriskTable . "` where `calldate` BETWEEN '" . $from . " 00:00:00' AND '" . $to . " 23:59:59'  AND `lastapp`='dial' ORDER BY `calldate` DESC";
+            $obj = $this;
+            $cacheName = $from . $to;
+            $rawResult = $this->cache->getCallback('ASTERISK_CDR_' . $cacheName, function()  use ($query, $obj) {
+                        return ($obj->AsteriskQuery($query));
+                        }, $this->config['cachetime']);
         }
 
         // Check for rawResult

--- a/api/libs/api.asterisk.php
+++ b/api/libs/api.asterisk.php
@@ -745,25 +745,6 @@ class Asterisk {
         $to = mysql_real_escape_string($to);
         $asteriskTable = mysql_real_escape_string($this->config['table']);
 
-       /* //caching
-        $cacheUpdate = true;
-        $cacheName = $from . $to;
-        $cacheName = md5($cacheName);
-        $cacheName = self::CACHE_PATH . 'ASTERISK_' . $cacheName;
-        $cachetime = time() - ($this->config['cachetime'] * 60);
-
-        if (file_exists($cacheName)) {
-            if ((filemtime($cacheName) > $cachetime)) {
-                $rawResult = file_get_contents($cacheName);
-                $rawResult = unserialize($rawResult);
-                $cacheUpdate = false;
-            } else {
-                $cacheUpdate = true;
-            }
-        } else {
-            $cacheUpdate = true;
-        }*/
-
         if (! empty($user_login)) {
             //fetch some data from Asterisk database
             $phone = @$this->result_LoginByNumber[$user_login]['phone'];
@@ -787,21 +768,14 @@ class Asterisk {
             }
             if (!empty($query)) {
                 $rawResult = $this->AsteriskQuery($query);
-                //$cacheContent = serialize($rawResult);
             }
         } elseif (wf_CheckPost(array('countnum')) and ! isset($user_login)) {
             $query = "select *,count(`src`) as `countnum`  from `" . $asteriskTable . "` where `calldate` BETWEEN '" . $from . " 00:00:00' AND '" . $to . " 23:59:59' AND `lastapp`='dial' GROUP BY `src`";
             $rawResult = $this->AsteriskQuery($query);
-            //$cacheContent = serialize($rawResult);
-        /*} elseif ($cacheUpdate and ! isset($user_login)) {
-            $query = "select * from `" . $asteriskTable . "` where `calldate` BETWEEN '" . $from . " 00:00:00' AND '" . $to . " 23:59:59'  AND `lastapp`='dial' ORDER BY `calldate` DESC";
-            $rawResult = $this->AsteriskQuery($query);
-            $cacheContent = serialize($rawResult);
-            file_put_contents($cacheName, $cacheContent);
-        }*/
         } else {
             // check if need clean cache 
             $this->AsterikCacheInfoClean($asteriskTable, $from, $to);
+            // Start check cache and get result
             $query = "select * from `" . $asteriskTable . "` where `calldate` BETWEEN '" . $from . " 00:00:00' AND '" . $to . " 23:59:59'  AND `lastapp`='dial' ORDER BY `calldate` DESC";
             $obj = $this;
             $cacheName = $from . $to;

--- a/api/libs/api.ubcache.php
+++ b/api/libs/api.ubcache.php
@@ -147,7 +147,7 @@ class UbillingCache {
     public function set($key, $data, $expiration = 0) {
         $key = $this->genKey($key);
         if ($this->storage == 'files') {
-            file_put_contents($this->storagePath . $key, $data);
+            file_put_contents($this->storagePath . $key, serialize($data));
         }
 
         if ($this->storage == 'memcached') {
@@ -189,7 +189,7 @@ class UbillingCache {
 
             if (!$updateCache) {
                 //read data directly from cache
-                $result = file_get_contents($cacheName);
+                $result = file_get_contents(unserialize($data));
             } else {
                 //cache expired, return empty result
                 $result = '';

--- a/api/libs/api.ubcache.php
+++ b/api/libs/api.ubcache.php
@@ -189,7 +189,8 @@ class UbillingCache {
 
             if (!$updateCache) {
                 //read data directly from cache
-                $result = file_get_contents(unserialize($data));
+                $data = file_get_contents($cacheName);
+                $result = unserialize($data);
             } else {
                 //cache expired, return empty result
                 $result = '';

--- a/api/libs/api.ubcache.php
+++ b/api/libs/api.ubcache.php
@@ -261,7 +261,7 @@ class UbillingCache {
             } else {
                 //run callback function and store new data into cache
                 $result = $callback();
-                $this->set($keyRaw, serialize($result), $expiration);
+                $this->set($keyRaw, $result, $expiration);
             }
             return ($result);
         }

--- a/api/libs/api.workaround.php
+++ b/api/libs/api.workaround.php
@@ -4809,7 +4809,7 @@ function zb_ListCacheInform($param = '') {
                 $cells.= wf_TableCell($key['key'], '', '', 'sorttable_customkey="' . $id . '"');
                 //$value = (is_array($key['value'])) ? serialize($key['value']) : $key['value'];
                 $value = wf_tag('pre') . print_r($key['value'], true) . wf_tag('pre', true);
-                $cells.= wf_TableCell(wf_modal(__('Cache data'), __('Cache information'), $value, 'ubButton', '800', '600'));
+                $cells.= wf_TableCell(wf_modal(__('Cache data'), __('Cache information') . ': ' . $key['key'], $value, 'ubButton', '800', '600'));
             } else {
                 $cells.= wf_TableCell($key, '', '', 'sorttable_customkey="' . $id . '"');
             }

--- a/api/libs/api.workaround.php
+++ b/api/libs/api.workaround.php
@@ -4807,8 +4807,9 @@ function zb_ListCacheInform($param = '') {
             $cells = wf_TableCell($id);
             if ($param == 'data') {
                 $cells.= wf_TableCell($key['key'], '', '', 'sorttable_customkey="' . $id . '"');
-                $value = (is_array($key['value'])) ? serialize($key['value']) : $key['value'];
-                $cells.= wf_TableCell($value);
+                //$value = (is_array($key['value'])) ? serialize($key['value']) : $key['value'];
+                $value = wf_tag('pre') . print_r($key['value'], true) . wf_tag('pre', true);
+                $cells.= wf_TableCell(wf_modal(__('Cache data'), __('Cache information'), $value, 'ubButton', '800', '600'));
             } else {
                 $cells.= wf_TableCell($key, '', '', 'sorttable_customkey="' . $id . '"');
             }


### PR DESCRIPTION
## Кэширование **memcached**
- Для memcached сериализация не нужна, так-как в его кэш можно впихнуть все, что угодно. Тем самым мы экономим много времени при доставании и засовывании данных с кэша, в кеш. Главное, что-бы размер данных занимал не более 1Мб (по умолчанию), ну а если все-таки больше:

в **rc.conf** добавить:

- `memcached_flags="-I 10M"`

и перезапустить **memcached**.

## Кэширование **файлы**
При использования стореджа кэша в виде фалов - сериализация нужна, так-как в файл можно запихнуть только `STRING`. При запихивании маленьких данных, файловый кэш выигрывает по времени, но при больших объемах очень проигрывает.
И еще один минус использования кэширования  в файлах, а то то, что ненужные файлы кэша не всегда удаляются.
## Плюшки

- добавлено прогрессивное кэширование для астериска (читаем ниже)
- добавлено кэширование для комментов