### PR TITLE
Очистка кода от функций ip2int int2ip

### DIFF
--- a/api/libs/api.documents.php
+++ b/api/libs/api.documents.php
@@ -214,7 +214,7 @@ class ProfileDocuments {
                 if ($this->altcfg['OPENPAYZ_REALID']) {
                     @$userdata[$eachuser['login']]['PAYID'] = $allopcustomers[$eachuser['login']];
                 } else {
-                    @$userdata[$eachuser['login']]['PAYID'] = ip2int($eachuser['IP']);
+                    @$userdata[$eachuser['login']]['PAYID'] = ip2long($eachuser['IP']);
                 }
                 //traffic params
                 $userdata[$eachuser['login']]['TRAFFIC'] = $eachuser['D0'] + $eachuser['U0'];

--- a/api/libs/api.extnets.php
+++ b/api/libs/api.extnets.php
@@ -224,20 +224,20 @@ class ExtNets {
                 //select last broadcast +1
                 foreach ($this->pools as $io=>$each) {
                     if ($each['netid']==$netid) {
-                        $curNetPools[$each['id']]=ip2int($each['broadcast'])+1;
+                        $curNetPools[$each['id']]=ip2long($each['broadcast'])+1;
                     }
                 } 
             } else {
                  //network start IP
-                $curNetPools[0]=ip2int($this->networks[$netid]['startip']);
+                $curNetPools[0]=ip2long($this->networks[$netid]['startip']);
             }
             
             if (empty($curNetPools)) {
                 //network start IP
-                $curNetPools[0]=ip2int($this->networks[$netid]['startip']);
+                $curNetPools[0]=ip2long($this->networks[$netid]['startip']);
             }
             $result=max($curNetPools);
-            $result=  int2ip($result);
+            $result=  long2ip($result);
         }
         return ($result);
     }
@@ -281,13 +281,13 @@ class ExtNets {
         nr_query($query);
         $newPoolId=  simple_get_lastid('netextpools');
         log_register("POOL CREATE [".$newPoolId."] `".$pool."/".$netmask."`");
-        $newGw=  int2ip(ip2int($pool)+1);
-        $newBroadcast=int2ip(ip2int($pool)+($this->cidrOffsets[$netmask]-1));
+        $newGw=  long2ip(ip2long($pool)+1);
+        $newBroadcast=long2ip(ip2long($pool)+($this->cidrOffsets[$netmask]-1));
         simple_update_field('netextpools', 'gw', $newGw, "WHERE `id`='".$newPoolId."';");
         simple_update_field('netextpools', 'broadcast', $newBroadcast, "WHERE `id`='".$newPoolId."';");
         //creating ips list for pool
-        $newIpsStart=  int2ip(ip2int($newGw)+1);
-        $newIpsEnd=  int2ip(ip2int($newBroadcast)-1);
+        $newIpsStart=  long2ip(ip2long($newGw)+1);
+        $newIpsEnd=  long2ip(ip2long($newBroadcast)-1);
         $this->ipsCreate($newPoolId, $newIpsStart, $newIpsEnd);
         
     }
@@ -371,12 +371,12 @@ class ExtNets {
      */
     protected function ipsCreate($poolid,$begin,$end) {
         $poolid=vf($poolid,3);
-        $begin=  ip2int($begin);
-        $end= ip2int($end);
+        $begin=  ip2long($begin);
+        $end= ip2long($end);
             //valid ips ugly check
             if ($begin<=$end) {
                 for ($i=$begin;$i<=$end;$i++) {
-                    $newIp=  int2ip($i);
+                    $newIp=  long2ip($i);
                     $query="INSERT INTO `netextips` "
                          . "(`id`, `poolid`, `ip`, `nas`, `iface`, `mac`, `switchid`, `port`, `vlan`) "
                          . "VALUES (NULL, '".$poolid."', '".$newIp."', NULL, NULL, NULL, NULL, NULL, NULL); ";
@@ -385,7 +385,7 @@ class ExtNets {
                
             }
         
-       log_register("POOL [".$poolid."] IPS CREATE RANGE `".int2ip($begin)."-".int2ip($end)."` ");
+       log_register("POOL [".$poolid."] IPS CREATE RANGE `".long2ip($begin)."-".long2ip($end)."` ");
     }
     
     

--- a/api/libs/api.globalsearch.php
+++ b/api/libs/api.globalsearch.php
@@ -212,7 +212,7 @@ class GlobalSearch {
                     $tmpArrPayids = array();
                     if (!empty($allPayIds)) {
                         foreach ($allPayIds as $io => $each) {
-                            $tmpArrPayids[$each['login']] = ip2int($each['IP']);
+                            $tmpArrPayids[$each['login']] = ip2long($each['IP']);
                         }
                     }
                     $this->rawData = $this->rawData + $this->transformArray($tmpArrPayids, __('Payment ID'), 'payid');

--- a/api/libs/api.networking.php
+++ b/api/libs/api.networking.php
@@ -639,7 +639,7 @@ function multinet_rebuild_globalconf() {
             $templatedata['{CIDR}'] = explode('/', $netdata['desc']);
             $templatedata['{NETWORK}'] = $templatedata['{CIDR}'][0];
             $templatedata['{CIDR}'] = $templatedata['{CIDR}'][1];
-            $templatedata['{ROUTERS}'] = int2ip(ip2int($templatedata['{STARTIP}']) + 1);
+            $templatedata['{ROUTERS}'] = long2ip(ip2long($templatedata['{STARTIP}']) + 1);
             $templatedata['{MASK}'] = multinet_cidr2mask($templatedata['{CIDR}']);
             $dhcpdata = dhcp_get_data_by_netid($eachnet['netid']);
             if (isset($dhcpdata['confname'])) {
@@ -733,10 +733,10 @@ function multinet_change_mac($ip, $newmac) {
 }
 
 function multinet_expand_network($first_ip, $last_ip) {
-    $first = ip2int($first_ip);
-    $last = ip2int($last_ip);
+    $first = ip2long($first_ip);
+    $last = ip2long($last_ip);
     for ($i = $first; $i <= $last; $i++) {
-        $totalnet[] = int2ip($i);
+        $totalnet[] = long2ip($i);
     }
     if (!empty($totalnet)) {
         foreach ($totalnet as $eachip) {
@@ -750,20 +750,6 @@ function multinet_expand_network($first_ip, $last_ip) {
         }
     }
     return($filterednet);
-}
-
-function ip2int($src) {
-    $t = explode('.', $src);
-    return count($t) != 4 ? 0 : 256 * (256 * ((float) $t[0] * 256 + (float) $t[1]) + (float) $t[2]) + (float) $t[3];
-}
-
-function int2ip($src) {
-    $s1 = (int) ($src / 256);
-    $i1 = $src - 256 * $s1;
-    $src = (int) ($s1 / 256);
-    $i2 = $s1 - 256 * $src;
-    $s1 = (int) ($src / 256);
-    return sprintf('%d.%d.%d.%d', $s1, $src - 256 * $s1, $i2, $i1);
 }
 
 function multinet_get_all_free_ip($table, $field, $network_id) {

--- a/api/libs/api.switches.php
+++ b/api/libs/api.switches.php
@@ -880,7 +880,7 @@ function web_SwitchesShow() {
 
 
             $tablecells = wf_TableCell($eachswitch['id']);
-            $tablecells.=wf_TableCell($eachswitch['ip'], '', '', 'sorttable_customkey="' . ip2int($eachswitch['ip']) . '"');
+            $tablecells.=wf_TableCell($eachswitch['ip'], '', '', 'sorttable_customkey="' . ip2long($eachswitch['ip']) . '"');
             $tablecells.=wf_TableCell($eachswitch['location']);
             $tablecells.=wf_TableCell($aliveled, '', '', 'sorttable_customkey="' . $aliveflag . '"');
             $tablecells.=wf_TableCell(@$modelnames[$eachswitch['modelid']]);

--- a/api/libs/api.templatize.php
+++ b/api/libs/api.templatize.php
@@ -128,7 +128,7 @@ function zb_TemplateGetAllUserData() {
             if ($altcfg['OPENPAYZ_REALID']) {
                 @$userdata[$eachuser['login']]['payid'] = $allopcustomers[$eachuser['login']];
             } else {
-                @$userdata[$eachuser['login']]['payid'] = ip2int($eachuser['IP']);
+                @$userdata[$eachuser['login']]['payid'] = ip2long($eachuser['IP']);
             }
             //traffic params
             $userdata[$eachuser['login']]['traffic'] = $eachuser['D0'] + $eachuser['U0'];

--- a/api/libs/api.userprofile.php
+++ b/api/libs/api.userprofile.php
@@ -425,7 +425,7 @@ class UserProfile {
         if ($this->alterCfg['OPENPAYZ_REALID']) {
             $this->paymentid = zb_PaymentIDGet($this->login);
         } else {
-            $this->paymentid = ip2int($this->userdata['IP']);
+            $this->paymentid = ip2long($this->userdata['IP']);
         }
     }
 

--- a/api/libs/api.usersearch.php
+++ b/api/libs/api.usersearch.php
@@ -117,7 +117,7 @@ function zb_UserSearchFields($query, $searchtype) {
         if ($altercfg['OPENPAYZ_REALID']) {
             $query = "SELECT `realid` AS `login` from `op_customers` WHERE `virtualid`='" . $query . "'";
         } else {
-            $query = "SELECT `login` from `users` WHERE `IP` = '" . int2ip($query) . "'";
+            $query = "SELECT `login` from `users` WHERE `IP` = '" . long2ip($query) . "'";
         }
     }
 

--- a/api/libs/api.userside.php
+++ b/api/libs/api.userside.php
@@ -739,7 +739,7 @@ class UserSideApi {
         } else {
             if (!empty($this->allUserData)) {
                 foreach (@$this->allUserData as $io => $each) {
-                    $result[$each['login']] = ip2int($each['IP']);
+                    $result[$each['login']] = ip2long($each['IP']);
                 }
             }
         }
@@ -979,7 +979,7 @@ class UserSideApi {
                 }
 
                 $userIp = $userData['IP'];
-                $userIp = ip2int($userIp);
+                $userIp = ip2long($userIp);
                 $result[$userLogin]['ip_mac'][0]['ip'] = $userIp;
                 $nethostsData = @$allNethosts[$userData['IP']];
                 if (!empty($nethostsData)) {

--- a/api/libs/api.whois.php
+++ b/api/libs/api.whois.php
@@ -183,7 +183,7 @@ class UbillingWhois {
             $rows.=wf_TableRow($cells, 'row3');
             $cells = wf_TableCell(__('IP range'), '', 'row2');
             if ((!empty($this->ispData->ip_range_start)) AND ( !empty($this->ispData->ip_range_end))) {
-                $ipRange = int2ip($this->ispData->ip_range_start) . ' - ' . int2ip($this->ispData->ip_range_end);
+                $ipRange = long2ip($this->ispData->ip_range_start) . ' - ' . long2ip($this->ispData->ip_range_end);
             } else {
                 $ipRange = '';
             }

--- a/api/libs/api.workaround.php
+++ b/api/libs/api.workaround.php
@@ -2758,7 +2758,7 @@ function web_UserArrayShower($usersarr) {
             $tablecells = wf_TableCell($profilelink);
             $tablecells.=wf_TableCell(@$alladdress[$eachlogin]);
             $tablecells.=wf_TableCell(@$allrealnames[$eachlogin]);
-            $tablecells.=wf_TableCell(@$alluserips[$eachlogin], '', '', 'sorttable_customkey="' . ip2int(@$alluserips[$eachlogin]) . '"');
+            $tablecells.=wf_TableCell(@$alluserips[$eachlogin], '', '', 'sorttable_customkey="' . ip2long(@$alluserips[$eachlogin]) . '"');
             $tablecells.=wf_TableCell(@$alltariffs[$eachlogin]);
             if ($alterconf['ONLINE_LAT']) {
                 if (isset($alluserlat[$eachlogin])) {

--- a/modules/general/genocide/index.php
+++ b/modules/general/genocide/index.php
@@ -113,7 +113,7 @@ function gen_check_users() {
              $tablecells.=wf_TableCell(@$alluseraddress[$eachuser['login']]);
              $tablecells.=wf_TableCell(@$allusernames[$eachuser['login']]);
              $tablecells.=wf_TableCell($eachuser['Tariff']);
-             $tablecells.=wf_TableCell($eachuser['IP'],'','','sorttable_customkey="'.ip2int($eachuser['IP']).'"');
+             $tablecells.=wf_TableCell($eachuser['IP'],'','','sorttable_customkey="'.ip2long($eachuser['IP']).'"');
              $tablecells.=wf_TableCell(stg_convert_size($eachuser['D0']),'','','sorttable_customkey="'.$eachuser['D0'].'"');
              $tablecells.=wf_TableCell(stg_convert_size($eachuser['U0']),'','','sorttable_customkey="'.$eachuser['U0'].'"');
              $tablecells.=wf_TableCell(stg_convert_size(($eachuser['D0']+$eachuser['U0'])),'','','sorttable_customkey="'.($eachuser['D0']+$eachuser['U0']).'"');

--- a/modules/general/turbosms/index.php
+++ b/modules/general/turbosms/index.php
@@ -37,7 +37,7 @@ if (cfr('TURBOSMS')) {
            $all = simple_queryall($query);
            if (!empty($all)) {
                foreach ($all as $io=>$each) {
-                   $result[$each['login']] = ip2int($each['IP']);
+                   $result[$each['login']] = ip2long($each['IP']);
                }
            }
        }

--- a/openpayz/docs/dump.sql
+++ b/openpayz/docs/dump.sql
@@ -24,7 +24,7 @@ CREATE TABLE IF NOT EXISTS `op_transactions` (
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 AUTO_INCREMENT=1 ;
 
 -- view for compat with ubilling
--- transform users.login -> ip2int(users.IP);
+-- transform users.login -> ip2long(users.IP);
 -- CREATE VIEW op_customers (realid,virtualid) AS SELECT users.login, INET_ATON(users.IP) from `users`;
 
 

--- a/openpayz/libs/api.openpayz.php
+++ b/openpayz/libs/api.openpayz.php
@@ -181,34 +181,6 @@ function xml2array($contents, $get_attributes = 1, $priority = 'tag') {
 }
 
 /**
- * Converts IP address into integer value
- * 
- * @param string $src
- * 
- * @return int
- */
-function ip2int($src) {
-    $t = explode('.', $src);
-    return count($t) != 4 ? 0 : 256 * (256 * ((float) $t[0] * 256 + (float) $t[1]) + (float) $t[2]) + (float) $t[3];
-}
-
-/**
- * Converts integer value into IP address
- * 
- * @param int $src
- * 
- * @return string
- */
-function int2ip($src) {
-    $s1 = (int) ($src / 256);
-    $i1 = $src - 256 * $s1;
-    $src = (int) ($s1 / 256);
-    $i2 = $s1 - 256 * $src;
-    $s1 = (int) ($src / 256);
-    return sprintf('%d.%d.%d.%d', $s1, $src - 256 * $s1, $i2, $i1);
-}
-
-/**
  * Returns plain array of not processed transactions
  * 
  * @return array

--- a/userstats/modules/engine/api.compat.php
+++ b/userstats/modules/engine/api.compat.php
@@ -246,32 +246,6 @@ function curdatetime() {
 }
 
 /**
- * Converts string IP address into integer
- * 
- * @param string $src
- * @return int
- */
-function ip2int($src) {
-    $t = explode('.', $src);
-    return count($t) != 4 ? 0 : 256 * (256 * ((float) $t[0] * 256 + (float) $t[1]) + (float) $t[2]) + (float) $t[3];
-}
-
-/**
- * Converts integer into IP address
- * 
- * @param int $src
- * @return string
- */
-function int2ip($src) {
-    $s1 = (int) ($src / 256);
-    $i1 = $src - 256 * $s1;
-    $src = (int) ($s1 / 256);
-    $i2 = $s1 - 256 * $src;
-    $s1 = (int) ($src / 256);
-    return sprintf('%d.%d.%d.%d', $s1, $src - 256 * $s1, $i2, $i1);
-}
-
-/**
  * Returns random string with some length
  * 
  * @param int $size

--- a/userstats/modules/engine/api.documents.php
+++ b/userstats/modules/engine/api.documents.php
@@ -206,7 +206,7 @@ class UsProfileDocuments {
             if ($this->altcfg['OPENPAYZ_REALID']) {
                 @$userdata[$alluserdata['login']]['PAYID'] = $allopcustomer;
             } else {
-                @$userdata[$alluserdata['login']]['PAYID'] = ip2int($alluserdata['IP']);
+                @$userdata[$alluserdata['login']]['PAYID'] = ip2long($alluserdata['IP']);
             }
             //traffic params
             $userdata[$alluserdata['login']]['TRAFFIC'] = $alluserdata['D0'] + $alluserdata['U0'];

--- a/userstats/modules/engine/api.userstats.php
+++ b/userstats/modules/engine/api.userstats.php
@@ -535,7 +535,7 @@ function zbs_UserShowAgentData($login) {
     $result.='email=' . $email . "\n";
     $result.='credit=' . @$userdata['Credit'] . "\n";
     $result.='creditexpire=' . $credexpire . "\n";
-    $result.='payid=' . ip2int($userdata['IP']) . "\n";
+    $result.='payid=' . ip2long($userdata['IP']) . "\n";
     $result.='contract=' . $contract . "\n";
     $result.='tariff=' . $userdata['Tariff'] . "\n";
     $result.='tariffnm=' . $userdata['TariffChange'] . "\n";
@@ -632,7 +632,7 @@ function zbs_UserShowXmlAgentData($login) {
     if ($us_config['OPENPAYZ_REALID']) {
         $paymentid = zbs_PaymentIDGet($login);
     } else {
-        $paymentid = ip2int($userdata['IP']);
+        $paymentid = ip2long($userdata['IP']);
     }
 
     if ($userdata['CreditExpire'] != 0) {
@@ -989,7 +989,7 @@ function zbs_UserShowProfile($login) {
     if ($us_config['OPENPAYZ_REALID']) {
         $paymentid = zbs_PaymentIDGet($login);
     } else {
-        $paymentid = ip2int($userdata['IP']);
+        $paymentid = ip2long($userdata['IP']);
     }
 
     //payment id qr dialog

--- a/userstats/modules/general/opayz/index.php
+++ b/userstats/modules/general/opayz/index.php
@@ -131,7 +131,7 @@ if ($us_config['OPENPAYZ_ENABLED']) {
                 $this->userLogin = zbs_UserGetLoginByIp($this->userIp);
                 $this->paymentId = zbs_PaymentIDGet($this->userLogin);
             } else {
-                $this->paymentId = ip2int($this->userIp);
+                $this->paymentId = ip2long($this->userIp);
             }
         }
 


### PR DESCRIPTION
Эти функции заменены на стандартные `ip2long ` `long2ip`, которые работают в 2 раза быстрее
![callgraph-1](https://user-images.githubusercontent.com/11805503/30314482-81ced0f0-97a9-11e7-93ed-af6a6a2e8348.png)
![callgraph-2](https://user-images.githubusercontent.com/11805503/30314491-868a3e86-97a9-11e7-8a26-01084a36c620.png)
