### PR TITLE
Fix for PHP 7.1

### DIFF
--- a/api/libs/api.mysql.php
+++ b/api/libs/api.mysql.php
@@ -79,7 +79,7 @@ if (!extension_loaded('mysql')) {
         if (DEBUG) {
             print ($query . "\n");
         }
-        $result = '';
+        $result = array();
         $queried = $loginDB->query($query) or die('wrong data input: ' . $query);
         while ($row = mysqli_fetch_assoc($queried)) {
             $result[] = $row;


### PR DESCRIPTION
This small patch seems to fix errors like this:
PHP Fatal error:  Uncaught Error: [] operator not supported for strings in /var/www/ubilling/api/libs/api.mysql.php:85

On PHP 7.1