### PR TITLE
Fixed SQL-error when adding employee without tag or setting an empty tag to when editing an employee. 

### DIFF
--- a/api/libs/api.mysql.php
+++ b/api/libs/api.mysql.php
@@ -113,12 +113,19 @@ if (!extension_loaded('mysql')) {
      * @param string $field
      * @param string $value
      * @param string $where
+     * @param bool $NoQuotesAroundValue
      */
-    function simple_update_field($tablename, $field, $value, $where = '') {
+    function simple_update_field($tablename, $field, $value, $where = '', $NoQuotesAroundValue = false) {
         $tablename = loginDB_real_escape_string($tablename);
         $value = loginDB_real_escape_string($value);
         $field = loginDB_real_escape_string($field);
-        $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+
+        if ($NoQuotesAroundValue) {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = " . $value . " " . $where . "";
+        } else {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+        }
+
         nr_query($query);
     }
 
@@ -365,12 +372,19 @@ if (!extension_loaded('mysql')) {
      * @param string $field
      * @param string $value
      * @param string $where
+     * @param bool $NoQuotesAroundValue
      */
-    function simple_update_field($tablename, $field, $value, $where = '') {
+    function simple_update_field($tablename, $field, $value, $where = '', $NoQuotesAroundValue = false) {
         $tablename = mysql_real_escape_string($tablename);
         $value = mysql_real_escape_string($value);
         $field = mysql_real_escape_string($field);
-        $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+
+        if ($NoQuotesAroundValue) {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = " . $value . " " . $where . "";
+        } else {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+        }
+
         nr_query($query);
     }
 

--- a/api/libs/api.taskman.php
+++ b/api/libs/api.taskman.php
@@ -9,7 +9,7 @@
  */
 function em_TagSelector($name, $label = '', $selected = '', $br = false) {
     $alltypes = stg_get_alltagnames();
-    $allltags = array('' => '-');
+    $allltags = array('NULL' => '-');
     if (!empty($alltypes)) {
         foreach ($alltypes as $io => $eachtype) {
             $allltags[$io] = $eachtype . " (" . $io . ")";
@@ -147,7 +147,7 @@ function em_EmployeeAdd($name, $job, $mobile = '', $telegram = '', $admlogin = '
     $admlogin = mysql_real_escape_string($admlogin);
     $tagid = mysql_real_escape_string($tagid);
     $query = "INSERT INTO `employee` (`id` , `name` , `appointment`, `mobile`, `telegram`, `admlogin`, `active`, `tagid`)
-              VALUES (NULL , '" . $name . "', '" . $job . "','" . $mobile . "','" . $telegram . "' ,'" . $admlogin . "' , '1', '" . $tagid . "'); ";
+              VALUES (NULL , '" . $name . "', '" . $job . "','" . $mobile . "','" . $telegram . "' ,'" . $admlogin . "' , '1', " . $tagid . "); ";
     nr_query($query);
     log_register('EMPLOYEE ADD `' . $name . '` JOB `' . $job . '`');
 }

--- a/docs/opt82_uhw/libs/api.mysql.php
+++ b/docs/opt82_uhw/libs/api.mysql.php
@@ -113,12 +113,19 @@ if (!extension_loaded('mysql')) {
      * @param string $field
      * @param string $value
      * @param string $where
+     * @param bool $NoQuotesAroundValue
      */
-    function simple_update_field($tablename, $field, $value, $where = '') {
+    function simple_update_field($tablename, $field, $value, $where = '', $NoQuotesAroundValue = false) {
         $tablename = loginDB_real_escape_string($tablename);
         $value = loginDB_real_escape_string($value);
         $field = loginDB_real_escape_string($field);
-        $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+
+        if ($NoQuotesAroundValue) {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = " . $value . " " . $where . "";
+        } else {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+        }
+
         nr_query($query);
     }
 
@@ -364,12 +371,19 @@ if (!extension_loaded('mysql')) {
      * @param string $field
      * @param string $value
      * @param string $where
+     * @param bool $NoQuotesAroundValue
      */
-    function simple_update_field($tablename, $field, $value, $where = '') {
+    function simple_update_field($tablename, $field, $value, $where = '', $NoQuotesAroundValue = false) {
         $tablename = mysql_real_escape_string($tablename);
         $value = mysql_real_escape_string($value);
         $field = mysql_real_escape_string($field);
-        $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+
+        if ($NoQuotesAroundValue) {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = " . $value . " " . $where . "";
+        } else {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+        }
+
         nr_query($query);
     }
 

--- a/docs/signup2/modules/engine/api.mysql.php
+++ b/docs/signup2/modules/engine/api.mysql.php
@@ -112,12 +112,19 @@ if (!extension_loaded('mysql')) {
      * @param string $field
      * @param string $value
      * @param string $where
+     * @param bool $NoQuotesAroundValue
      */
-    function simple_update_field($tablename, $field, $value, $where = '') {
+    function simple_update_field($tablename, $field, $value, $where = '', $NoQuotesAroundValue = false) {
         $tablename = loginDB_real_escape_string($tablename);
         $value = loginDB_real_escape_string($value);
         $field = loginDB_real_escape_string($field);
-        $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+
+        if ($NoQuotesAroundValue) {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = " . $value . " " . $where . "";
+        } else {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+        }
+
         nr_query($query);
     }
 
@@ -363,12 +370,19 @@ if (!extension_loaded('mysql')) {
      * @param string $field
      * @param string $value
      * @param string $where
+     * @param bool $NoQuotesAroundValue
      */
-    function simple_update_field($tablename, $field, $value, $where = '') {
+    function simple_update_field($tablename, $field, $value, $where = '', $NoQuotesAroundValue = false) {
         $tablename = mysql_real_escape_string($tablename);
         $value = mysql_real_escape_string($value);
         $field = mysql_real_escape_string($field);
-        $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+
+        if ($NoQuotesAroundValue) {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = " . $value . " " . $where . "";
+        } else {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+        }
+
         nr_query($query);
     }
 

--- a/docs/uhw/libs/api.mysql.php
+++ b/docs/uhw/libs/api.mysql.php
@@ -113,12 +113,19 @@ if (!extension_loaded('mysql')) {
      * @param string $field
      * @param string $value
      * @param string $where
+     * @param bool $NoQuotesAroundValue
      */
-    function simple_update_field($tablename, $field, $value, $where = '') {
+    function simple_update_field($tablename, $field, $value, $where = '', $NoQuotesAroundValue = false) {
         $tablename = loginDB_real_escape_string($tablename);
         $value = loginDB_real_escape_string($value);
         $field = loginDB_real_escape_string($field);
-        $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+
+        if ($NoQuotesAroundValue) {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = " . $value . " " . $where . "";
+        } else {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+        }
+
         nr_query($query);
     }
 
@@ -364,12 +371,19 @@ if (!extension_loaded('mysql')) {
      * @param string $field
      * @param string $value
      * @param string $where
+     * @param bool $NoQuotesAroundValue
      */
-    function simple_update_field($tablename, $field, $value, $where = '') {
+    function simple_update_field($tablename, $field, $value, $where = '', $NoQuotesAroundValue = false) {
         $tablename = mysql_real_escape_string($tablename);
         $value = mysql_real_escape_string($value);
         $field = mysql_real_escape_string($field);
-        $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+
+        if ($NoQuotesAroundValue) {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = " . $value . " " . $where . "";
+        } else {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+        }
+
         nr_query($query);
     }
 

--- a/modules/general/employee/index.php
+++ b/modules/general/employee/index.php
@@ -62,7 +62,7 @@ if (cfr('EMPLOYEEDIR')) {
             simple_update_field('employee', 'mobile', $_POST['editmobile'], "WHERE `id`='" . $editemployee . "'");
             simple_update_field('employee', 'telegram', $_POST['edittelegram'], "WHERE `id`='" . $editemployee . "'");
             simple_update_field('employee', 'admlogin', $_POST['editadmlogin'], "WHERE `id`='" . $editemployee . "'");
-            simple_update_field('employee', 'tagid', $_POST['editadtagid'], "WHERE `id`='" . $editemployee . "'");
+            simple_update_field('employee', 'tagid', $_POST['editadtagid'], "WHERE `id`='" . $editemployee . "'", true);
 
             if (wf_CheckPost(array('editactive'))) {
                 simple_update_field('employee', 'active', '1', "WHERE `id`='" . $editemployee . "'");

--- a/openpayz/libs/api.mysql.php
+++ b/openpayz/libs/api.mysql.php
@@ -113,12 +113,19 @@ if (!extension_loaded('mysql')) {
      * @param string $field
      * @param string $value
      * @param string $where
+     * @param bool $NoQuotesAroundValue
      */
-    function simple_update_field($tablename, $field, $value, $where = '') {
+    function simple_update_field($tablename, $field, $value, $where = '', $NoQuotesAroundValue = false) {
         $tablename = loginDB_real_escape_string($tablename);
         $value = loginDB_real_escape_string($value);
         $field = loginDB_real_escape_string($field);
-        $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+
+        if ($NoQuotesAroundValue) {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = " . $value . " " . $where . "";
+        } else {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+        }
+
         nr_query($query);
     }
 
@@ -365,12 +372,19 @@ if (!extension_loaded('mysql')) {
      * @param string $field
      * @param string $value
      * @param string $where
+     * @param bool $NoQuotesAroundValue
      */
-    function simple_update_field($tablename, $field, $value, $where = '') {
+    function simple_update_field($tablename, $field, $value, $where = '', $NoQuotesAroundValue = false) {
         $tablename = mysql_real_escape_string($tablename);
         $value = mysql_real_escape_string($value);
         $field = mysql_real_escape_string($field);
-        $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+
+        if ($NoQuotesAroundValue) {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = " . $value . " " . $where . "";
+        } else {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+        }
+
         nr_query($query);
     }
 

--- a/userstats/modules/engine/api.mysql.php
+++ b/userstats/modules/engine/api.mysql.php
@@ -112,12 +112,19 @@ if (!extension_loaded('mysql')) {
      * @param string $field
      * @param string $value
      * @param string $where
+     * @param bool $NoQuotesAroundValue
      */
-    function simple_update_field($tablename, $field, $value, $where = '') {
+    function simple_update_field($tablename, $field, $value, $where = '', $NoQuotesAroundValue = false) {
         $tablename = loginDB_real_escape_string($tablename);
         $value = loginDB_real_escape_string($value);
         $field = loginDB_real_escape_string($field);
-        $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+
+        if ($NoQuotesAroundValue) {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = " . $value . " " . $where . "";
+        } else {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+        }
+
         nr_query($query);
     }
 
@@ -363,12 +370,19 @@ if (!extension_loaded('mysql')) {
      * @param string $field
      * @param string $value
      * @param string $where
+     * @param bool $NoQuotesAroundValue
      */
-    function simple_update_field($tablename, $field, $value, $where = '') {
+    function simple_update_field($tablename, $field, $value, $where = '', $NoQuotesAroundValue = false) {
         $tablename = mysql_real_escape_string($tablename);
         $value = mysql_real_escape_string($value);
         $field = mysql_real_escape_string($field);
-        $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+
+        if ($NoQuotesAroundValue) {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = " . $value . " " . $where . "";
+        } else {
+            $query = "UPDATE `" . $tablename . "` SET `" . $field . "` = '" . $value . "' " . $where . "";
+        }
+
         nr_query($query);
     }
 


### PR DESCRIPTION
Besides, all declarations of simple_update_field() functions are updated: NoQuotesAroundValue parameter added. Setting this parameter to true prevents adding single quotes around the "value" part of SQL-query.