### PR TITLE
FREEZE_DAYS_CHARGE

### DIFF
--- a/api/libs/api.userprofile.php
+++ b/api/libs/api.userprofile.php
@@ -455,12 +455,12 @@ class UserProfile {
      * 
      * @return string
      */
-    protected function addRow($header, $data, $highlight = false) {
+    protected function addRow($header, $data, $highlight = false, $cellwidth = self::MAIN_ROW_HEADER_WIDTH) {
         if ($highlight) {
-            $cells = wf_TableCell($this->highlightStart . $header . $this->highlightEnd, self::MAIN_ROW_HEADER_WIDTH, 'row2');
+            $cells = wf_TableCell($this->highlightStart . $header . $this->highlightEnd, $cellwidth, 'row2');
             $cells.= wf_TableCell($this->highlightStart . $data . $this->highlightEnd, '', 'row3');
         } else {
-            $cells = wf_TableCell($header, self::MAIN_ROW_HEADER_WIDTH, 'row2');
+            $cells = wf_TableCell($header, $cellwidth, 'row2');
             $cells.= wf_TableCell($data, '', 'row3');
         }
         $result = wf_TableRow($cells);
@@ -1205,6 +1205,7 @@ class UserProfile {
         return ($result);
     }
 
+
     /**
       Брат, братан, братишка Когда меня отпустит?
      */
@@ -1304,6 +1305,23 @@ class UserProfile {
         $profile.=$this->addRow(__('Disable detailed stats'), web_trigger($this->userdata['DisabledDetailStat']));
 //Frozen aka passive flag row
         $profile.=$this->addRow(__('Freezed'), $passiveicon . web_trigger($this->userdata['Passive']), true);
+
+        if ( isset($this->alterCfg['FREEZE_DAYS_CHARGE_ENABLED']) && $this->alterCfg['FREEZE_DAYS_CHARGE_ENABLED'] ) {
+            $FrozenAllQuery = "SELECT * FROM `frozen_charge_days` WHERE `login` = '" . $this->userdata['login'] . "';";
+            $FrozenAll = simple_queryall($FrozenAllQuery);
+
+            if (!empty($FrozenAll)) {
+                foreach ($FrozenAll as $usr => $usrlogin) {
+                    $profile .= $this->addRow("&nbsp&nbsp&nbsp&nbsp" . __('Freeze days total amount'), $usrlogin['freeze_days_amount'], false, '50%');
+                    $profile .= $this->addRow("&nbsp&nbsp&nbsp&nbsp" . __('Freeze days used'), $usrlogin['freeze_days_used'], false, '50%');
+                    $profile .= $this->addRow("&nbsp&nbsp&nbsp&nbsp" . __('Freeze days available'), $usrlogin['freeze_days_amount'] - $usrlogin['freeze_days_used'], false, '50%');
+                    $profile .= $this->addRow("&nbsp&nbsp&nbsp&nbsp" . __('Workdays amount to restore freeze days'), $usrlogin['work_days_restore'], false, '50%');
+                    $profile .= $this->addRow("&nbsp&nbsp&nbsp&nbsp" . __('Days worked after freeze days used up'), $usrlogin['days_worked'], false, '50%');
+                    $profile .= $this->addRow("&nbsp&nbsp&nbsp&nbsp" . __('Workdays left to restore'), $usrlogin['work_days_restore'] - $usrlogin['days_worked'], false, '50%');
+                }
+            }
+        }
+
 //Disable aka Down flag row
         $profile.=$this->addRow(__('Disabled'), $downicon . web_trigger($this->userdata['Down']), true);
 //Deal with it available tasks notification

--- a/config/alter.ini
+++ b/config/alter.ini
@@ -604,3 +604,9 @@ PON_QUICK_OLT_LINKS=1
 PON_OLT_INDIVIDUAL_REPOLL_AJAX=1
 ;Is PON signal history charts spoiler initially closed?
 PON_ONU_CHARTS_SPOILER_CLOSED=0
+;Are freeze days limited and count of them is enabled?
+FREEZE_DAYS_CHARGE_ENABLED=1
+;Amount of days initially available for user(can be individually changed from userprofile)
+FREEZE_DAYS_INITIAL_AMOUNT=365
+;Amount of days user has to work to get the amount of freeze days again after he spents out all his available freeze days(can be individually changed from userprofile)
+FREEZE_DAYS_WORK_TO_RESTORE=120

--- a/config/optsaltcfg
+++ b/config/optsaltcfg
@@ -298,6 +298,9 @@ RESETHARD=TRIGGER|Hard reset is enabled
 SORM_ENABLED=TRIGGER|SORM integration enabled
 POLLS_ENABLED=TRIGGER|Polls enabled
 LDAPMGR_ENABLED=TRIGGER|Is LDAP manager enabled
+FREEZE_DAYS_CHARGE_ENABLED=TRIGGER|Freeze days charge enabled
+FREEZE_DAYS_INITIAL_AMOUNT=VARCHAR|Freeze days initial amount
+FREEZE_DAYS_WORK_TO_RESTORE=VARCHAR|Workdays initial amount to restore freeze days amount
 CHAPTEREND_BEH=true
 
 
@@ -329,4 +332,6 @@ ONUAUTO_CONFIG=TRIGGER|Set pvid on onu copper port
 ONUMODELS_FILTER=TRIGGER|Use only device models with ONU string
 ONUREG_ZTE=TRIGGER|Is ONU register module is enabled
 ONU_MASTER_ENABLED=TRIGGER|Is ONU master module is enabled
+PON_OLT_INDIVIDUAL_REPOLL_AJAX=TRIGGER|Ajax OLT data refresh
+PON_QUICK_OLT_LINKS=TRIGGER|OLT quick links enabled
 CHAPTEREND_PON=true

--- a/content/updates/sql/0.8.9.sql
+++ b/content/updates/sql/0.8.9.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS `frozen_charge_days` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `login` varchar(255) NOT NULL,
+  `freeze_days_amount` smallint(3) NOT NULL DEFAULT 0,
+  `freeze_days_used`  smallint(3) NOT NULL DEFAULT 0,
+  `work_days_restore` smallint(3) NOT NULL DEFAULT 0,
+  `days_worked` smallint(3) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY (`login`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 AUTO_INCREMENT=1

--- a/languages/russian/billing.php
+++ b/languages/russian/billing.php
@@ -2837,9 +2837,18 @@ $lang['def']['IP contains'] = 'IP содержит';
 $lang['def']['Balance is zero'] = 'Баланс нулевой';
 $lang['def']['User have credit'] = 'Установлен кредит';
 $lang['def']['Balance is less than zero'] = 'Баланс меньше нуля';
-$lang['def'][''] = '';
-$lang['def'][''] = '';
-
+$lang['def']['Freeze days charge enabled'] = 'Ограничение количества дней заморозки включено';
+$lang['def']['Freeze days initial amount'] = 'Начальное количество дней заморозки';
+$lang['def']['Workdays initial amount to restore freeze days amount'] = 'Начальное количество дней которые нужно отработать для восстановления дней заморозки';
+$lang['def']['Freeze days total amount'] = 'Общее количество дней заморозки';
+$lang['def']['Freeze days used'] = 'Количество использованных дней заморозки';
+$lang['def']['Freeze days available'] = 'Количество имеющихся для использования дней заморозки';
+$lang['def']['Workdays amount to restore freeze days'] = 'Количество дней которые нужно отработать для восстановления дней заморозки';
+$lang['def']['Days worked after freeze days used up'] = 'Количество уже отработаных дней после исчерпания дней заморозки';
+$lang['def']['Workdays left to restore'] = 'Количество дней которое осталось отработать для восстановления дней заморозки';
+$lang['def']['Changing freeze status is unavailable: total amount of freeze days used up'] = 'Изменение статуса заморозки недоступно: количество имеющихся дней заморозки исчерпано';
+$lang['def']['Ajax OLT data refresh'] = 'Обновление данных для OLT через AJAX включено';
+$lang['def']['OLT quick links enabled'] = 'Быстрый переход между OLT включен';
 
 
 

--- a/languages/ukrainian/billing.php
+++ b/languages/ukrainian/billing.php
@@ -2853,6 +2853,16 @@ $lang['def']['IP contains'] = 'IP містить';
 $lang['def']['Balance is zero'] = 'Баланс нульовий';
 $lang['def']['User have credit'] = 'Встановлено кредит';
 $lang['def']['Balance is less than zero'] = 'Баланс менший за нуль';
-
-
+$lang['def']['Freeze days charge enabled'] = 'Обмеження кількості днів заморозки ввімкнено';
+$lang['def']['Freeze days initial amount'] = 'Початкова кількість днів заморозки доступних для використання';
+$lang['def']['Workdays initial amount to restore freeze days amount'] = 'Початкова кількість днів які треба відпрацювати для відновлення днів заморозки';
+$lang['def']['Freeze days total amount'] = 'Загальна кількість днів заморозки';
+$lang['def']['Freeze days used'] = 'Кількість використанних днів заморозки';
+$lang['def']['Freeze days available'] = 'Кількість днів заморозки доступних для використання';
+$lang['def']['Workdays amount to restore freeze days'] = 'Кількість днів які треба відпрацювати для відновлення днів заморозки';
+$lang['def']['Days worked after freeze days used up'] = 'Кількість вже відпрацьованих днів після вичерпання днів заморозки';
+$lang['def']['Workdays left to restore'] = 'Кількість днів які залишилось відпрацювати для відновлення днів заморозки';
+$lang['def']['Changing freeze status is unavailable: total amount of freeze days used up'] = 'Зміна статусу заморозки недоступна: кількість днів заморозки вичерпано';
+$lang['def']['Ajax OLT data refresh'] = 'Оновлення даних для OLT через AJAX ввімкнено';
+$lang['def']['OLT quick links enabled'] = 'Швидкий перехід між OLT ввімкнено';
 ?>

--- a/modules/general/passiveedit/index.php
+++ b/modules/general/passiveedit/index.php
@@ -1,26 +1,121 @@
 <?php
 if (cfr('PASSIVE')) {
 
+$alterCfg = rcms_parse_ini_file(CONFIG_PATH . "alter.ini");
+$FreezeDaysChargeEnabled = ( isset($alterCfg['FREEZE_DAYS_CHARGE_ENABLED']) && $alterCfg['FREEZE_DAYS_CHARGE_ENABLED'] );
+$makeRedirect = false;
+$FreezingAvailable = true;
+
 if (isset ($_GET['username'])) {
     $login=vf($_GET['username']);
-       // change passive  if need
-       if (isset ($_POST['newpassive'])) {
+
+    if ($FreezeDaysChargeEnabled) {
+        if ( wf_CheckPost(array('newfreezedaysamnt')) ) {
+            simple_update_field('frozen_charge_days', 'freeze_days_amount', $_POST['newfreezedaysamnt'], "WHERE `login`='" . $login . "' ");
+            log_register('CHANGE Freeze days amount ('.$login.') ON '. $_POST['newfreezedaysamnt']);
+            $makeRedirect = true;
+        }
+
+        if ( wf_CheckPost(array('newwrkdaystorestorefrzdays')) ) {
+            simple_update_field('frozen_charge_days', 'work_days_restore', $_POST['newwrkdaystorestorefrzdays'], "WHERE `login`='" . $login . "' ");
+            log_register('CHANGE Workdays amount to restore freeze days ('.$login.') ON '. $_POST['newwrkdaystorestorefrzdays']);
+            $makeRedirect = true;
+        }
+    }
+
+   // change passive  if need
+    if ( isset($_POST['newpassive']) ) {
         $passive=$_POST['newpassive'];
         $billing->setpassive($login,$passive);
         log_register('CHANGE Passive ('.$login.') ON '.$passive);
-        rcms_redirect("?module=passiveedit&username=".$login);
+        $makeRedirect = true;
     }
+
+    if ($makeRedirect) {rcms_redirect("?module=passiveedit&username=".$login);}
 
     $current_passive=zb_UserGetStargazerData($login);
     $current_passive=$current_passive['Passive'];
     $useraddress=zb_UserGetFullAddress($login).' ('.$login.')';
 
+    $form  = '';
+    $form2 = '';
 
-// Edit form construct
-$fieldname=__('Current passive state');
-$fieldkey='newpassive';
-$form=web_EditorTrigerDataForm($fieldname, $fieldkey, $useraddress, $current_passive);
-$form.=web_UserControls($login);
+    if ($FreezeDaysChargeEnabled) {
+        $FrozenAllQuery = "SELECT * FROM `frozen_charge_days` WHERE `login` = '" . $login . "';";
+        $FrozenAll = simple_queryall($FrozenAllQuery);
+
+        if (!empty($FrozenAll)) {
+            foreach ($FrozenAll as $usr => $usrlogin) {
+                $FrzDaysAmount           = $usrlogin['freeze_days_amount'];
+                $FrzDaysUsed             = $usrlogin['freeze_days_used'];
+                $DaysWorked              = $usrlogin['days_worked'];
+                $WrkDaysToRestoreFrzDays = $usrlogin['work_days_restore'];
+
+                $inputs = '';
+
+                if ( ($FrzDaysUsed >= $FrzDaysAmount) && ($DaysWorked <= $WrkDaysToRestoreFrzDays) ) {
+                    $FreezingAvailable = false;
+
+                    $cells = wf_TableCell(__('User'), '', 'row2');
+                    $cells.= wf_TableCell($useraddress, '', 'row3');
+                    $rows.= wf_TableRow($cells);
+
+                    $cells = wf_TableCell(__('Current passive state'), '', 'row2');
+                    $cells.= wf_TableCell(web_trigger($current_passive), '', 'row2');
+                    $rows.= wf_TableRow($cells);
+                    $table = wf_TableBody($rows, '100%', 0, '');
+                    $inputs.= $table;
+                    $inputs.= wf_tag('h3', false, '', 'style="color:#e95802; font-weight:600"');
+                    $inputs.= __('Changing freeze status is unavailable: total amount of freeze days used up');
+                    $inputs.= wf_tag('h3', true);
+                    $inputs.= wf_delimiter();
+                }
+
+                $cells = wf_TableCell(__('Freeze days used'), '', 'row2');
+                $cells.= wf_TableCell($FrzDaysUsed, '', 'row2');
+                $rows = wf_TableRow($cells);
+
+                $cells = wf_TableCell(__('Freeze days available'), '', 'row2');
+                $cells.= wf_TableCell($FrzDaysAmount - $FrzDaysUsed, '', 'row2');
+                $rows.= wf_TableRow($cells);
+
+                $cells = wf_TableCell(__('Days worked after freeze days used up'), '', 'row2');
+                $cells.= wf_TableCell($DaysWorked, '', 'row2');
+                $rows.= wf_TableRow($cells);
+
+                $cells = wf_TableCell(__('Workdays left to restore'), '', 'row2');
+                $cells.= wf_TableCell($WrkDaysToRestoreFrzDays - $DaysWorked, '', 'row2');
+                $rows.= wf_TableRow($cells);
+
+                $cells = wf_TableCell(__('Freeze days total amount'), '', 'row2');
+                $cells.= wf_TableCell($FrzDaysAmount, '', 'row2');
+                $cells.= wf_TableCell(wf_TextInput('newfreezedaysamnt', '', '', false, 40), '', 'row3');
+                $rows.= wf_TableRow($cells);
+
+                $cells = wf_TableCell(__('Workdays amount to restore freeze days'), '', 'row2');
+                $cells.= wf_TableCell($WrkDaysToRestoreFrzDays, '', 'row2');
+                $cells.= wf_TableCell(wf_TextInput('newwrkdaystorestorefrzdays', '', '', false, 40), '', 'row3');
+                $rows.= wf_TableRow($cells);
+
+                $table = wf_TableBody($rows, '100%', 0, '');
+
+                $inputs.= $table;
+                $inputs.= wf_Submit(__('Change'));
+                $inputs.= wf_delimiter();
+                $form2 = wf_Form("", 'POST', $inputs, '');
+            }
+        }
+    }
+
+if ($FreezingAvailable) {
+    // Edit form construct
+    $fieldname = __('Current passive state');
+    $fieldkey = 'newpassive';
+    $form.= web_EditorTrigerDataForm($fieldname, $fieldkey, $useraddress, $current_passive);
+}
+
+$form.= wf_delimiter() . $form2;
+$form.= web_UserControls($login);
 // show form
 show_window(__('Edit passive'), $form);
 }

--- a/modules/general/remoteapi/index.php
+++ b/modules/general/remoteapi/index.php
@@ -407,8 +407,6 @@ if ($alterconf['REMOTEAPI_ENABLED']) {
                             }
                             if (!empty($allUsersToFreeze)) {
                                 foreach ($allUsersToFreeze as $efuidx => $eachfreezeuser) {
-
-
                                     $freezeLogin = $eachfreezeuser['login'];
                                     $freezeCash = $eachfreezeuser['Cash'];
                                     //zbs credit check
@@ -436,6 +434,82 @@ if ($alterconf['REMOTEAPI_ENABLED']) {
                             die('ERROR:NO_AUTOFREEZE_CASH_LIMIT');
                         }
                     }
+
+
+                    /*
+                     * running freeze days charge if FREEZE_DAYS_CHARGE_ENABLED
+                     */
+                    if ($_GET['action'] == 'freezedayscharge') {
+                        if ( isset($alterconf['FREEZE_DAYS_CHARGE_ENABLED']) && $alterconf['FREEZE_DAYS_CHARGE_ENABLED'] ) {
+                            $FreezeDaysInitAmnt                = $alterconf['FREEZE_DAYS_INITIAL_AMOUNT'];
+                            $WrkDaysToRestoreFrzDaysInitAmnt   = $alterconf['FREEZE_DAYS_WORK_TO_RESTORE'];
+
+                            $TmpQuery = "SELECT `users`.`login` FROM `users` 
+                                            LEFT JOIN `frozen_charge_days` ON `frozen_charge_days`.`login` = `users`.`login`
+                                            WHERE `users`.`Passive`='1' AND `frozen_charge_days`.`login` IS NULL;";
+                            $AllFrozenNotInCountTab = simple_queryall($TmpQuery);
+
+                            if ( !empty($AllFrozenNotInCountTab) ) {
+                                foreach ($AllFrozenNotInCountTab as $usr => $eachlogin) {
+                                    if ( $eachlogin['login'] == '63ap0_6g8g' ) {
+                                        $TmpQuery = "INSERT INTO `frozen_charge_days` (`login`, `freeze_days_amount`, `work_days_restore`)
+                                                                          VALUES  ('" . $eachlogin['login'] . "', '" . $FreezeDaysInitAmnt . "', '" . $WrkDaysToRestoreFrzDaysInitAmnt . "');";
+                                        nr_query($TmpQuery);
+                                    }
+                                }
+                            }
+
+                            $FrozenAllQuery = "SELECT `frozen_charge_days`.`*`, `users`.`Passive`, `users`.`Down`, `users`.`Credit`, `users`.`Cash` 
+                                                  FROM `frozen_charge_days`
+                                                  LEFT JOIN `users` ON `frozen_charge_days`.`login` = `users`.`login`;";
+                            $FrozenAll = simple_queryall($FrozenAllQuery);
+
+                            if ( !empty($FrozenAll) ) {
+                                $UsrPassive = 0;
+
+                                foreach ($FrozenAll as $usr => $eachlogin) {
+                                    $UsrLogin   = $eachlogin['login'];
+                                    $UsrPassive = $eachlogin['Passive'];
+                                    $UsrDown    = $eachlogin['Down'];
+                                    $UsrCredit  = $eachlogin['Credit'];
+                                    $UsrCash    = $eachlogin['Cash'];
+
+                                    $FrzDaysAmount              = $eachlogin['freeze_days_amount'];
+                                    $FrzDaysUsed                = $eachlogin['freeze_days_used'];
+                                    $DaysWorked                 = $eachlogin['days_worked'];
+                                    $WrkDaysToRestoreFrzDays    = $eachlogin['work_days_restore'];
+
+                                    if ($UsrPassive) {
+                                        $FrzDaysUsed++;
+
+                                        if ($FrzDaysUsed >= $FrzDaysAmount) {
+                                            $billing->setpassive($UsrLogin, '0');
+                                        }
+
+                                        simple_update_field('frozen_charge_days', 'freeze_days_used', $FrzDaysUsed, "WHERE `login`='" . $UsrLogin . "' ");
+                                    } else {
+                                        if ( ($FrzDaysUsed >= $FrzDaysAmount) && ($UsrCash < '-' . $UsrCredit) && !$UsrDown ) {
+                                            $DaysWorked++;
+
+                                            if ($DaysWorked >= $WrkDaysToRestoreFrzDays) {
+                                                $DaysWorked  = 0;
+                                                $FrzDaysUsed = 0;
+
+                                                simple_update_field('frozen_charge_days', 'freeze_days_used', $FrzDaysUsed, "WHERE `login`='" . $UsrLogin . "' ");
+                                            }
+
+                                            simple_update_field('frozen_charge_days', 'days_worked', $DaysWorked, "WHERE `login`='" . $UsrLogin . "' ");
+                                        }
+                                    }
+                                }
+
+                                die('OK:FREEZE_DAYS_CHARGE_NO_USERS');
+                            }
+
+                            die('OK:FREEZE_DAYS_CHARGE');
+                        }
+                    }
+
 
                     /*
                      * auto freezing call which use AUTOFREEZE_CASH_LIMIT as month count
@@ -496,6 +570,8 @@ if ($alterconf['REMOTEAPI_ENABLED']) {
                             die('ERROR:NO_AUTOFREEZE_CASH_LIMIT');
                         }
                     }
+
+
 
 
                     /*


### PR DESCRIPTION

New feature in make user passive(freezing user): now there is an ability to limit the amount of days during which user can be frozen and to set an amount of days  user must be avtive(not only to have enough money, but actually "work out" those days) - so to say - a cooldown period. The idea is: after user uses all the amount of freeze days that is available to him - he can't freeze the service anymore till he "works out" some amount of days. E.g. user has 365 days of freeze period and 120 days of cooldown(user must be active no less then 120 days). When passive is active - those 365 days ticks down and, when there is 0 days left - passive flag is removed and you(or usr itself) can't set it anymore, till cooldown period ends. All this stuff works via RemoteAPI call: freezedayscharge.

RemoteAPI:
    new remote call freezedayscharge which thought to run daily, preferably before the stargazer processing
    Crontab example: 40 23 * * *     /bin/ubapi "freezedayscharge"

alter.ini new options:
     FREEZE_DAYS_CHARGE_ENABLED - enables/disables the ability to charge freeze days
     FREEZE_DAYS_INITIAL_AMOUNT - initial amount of freeze days available to user(can be changed individually in user's profile)
     FREEZE_DAYS_WORK_TO_RESTORE - initial amount of cooldown days user need to be active to restore the amount of available freeze days(can be changed individually in user's profile)

DB:
    added new table `frozen_charge_days`  

added necessary translations