### PR TITLE
Получение MAC устройства при опросе по SNMP

### DIFF
--- a/api/libs/api.switches.php
+++ b/api/libs/api.switches.php
@@ -838,7 +838,7 @@ function web_SwitchesShow() {
                         $switchesGeo = zb_SwitchesGetAllGeo();
                     }
                     //ajax container
-                    $ajaxResult.=wf_tag('div', false, '', 'id="switchping"');
+                    $ajaxResult.= wf_tag('div', false, '', 'id="switchping"');
 
                     foreach ($deadarr as $ip => $switch) {
                         if ($alterconf['SWYMAP_ENABLED']) {
@@ -1011,7 +1011,7 @@ function web_SwitchesShow() {
 function web_SwitchesRenderList() {
     $result = '';
     $summaryCache = 'exports/switchcounterssummary.dat';
-    $columns = array('ID', 'IP', 'Location', 'Active', 'Model', 'SNMP community', 'Geo location', 'Description', 'Actions');
+    $columns = array('ID', 'IP', 'MAC', 'Location', 'Active', 'Model', 'SNMP community', 'Geo location', 'Description', 'Actions');
     $opts = '"order": [[ 0, "desc" ]]';
     $result = wf_JqDtLoader($columns, '?module=switches&ajaxlist=true', false, __('Switch'), 100, $opts);
     if (file_exists($summaryCache)) {
@@ -1085,8 +1085,18 @@ function zb_SwitchesRenderAjaxList() {
                 }
             }
 
+            $deviceMac = '';
+            $deviceMacCache = 'exports/' . $eachswitch['ip'] . '_MAC';
+            if (file_exists($deviceMacCache)) {
+                $deviceMac = file_get_contents($deviceMacCache);
+                if (!empty($deviceMac) and $deviceMac != $eachswitch['swid']) {
+                    $deviceMac = $deviceMac . ' ' . wf_img('skins/createtask.gif', __('MAC mismatch')) . ' ' . __('Oh no');
+                }
+            }
+
             $jsonItem[] = $eachswitch['id'];
             $jsonItem[] = $eachswitch['ip'];
+            $jsonItem[] = $deviceMac;
             $jsonItem[] = $eachswitch['location'];
             $jsonItem[] = $aliveled;
             $jsonItem[] = @$modelnames[$eachswitch['modelid']];

--- a/api/libs/api.swpoll.php
+++ b/api/libs/api.swpoll.php
@@ -171,7 +171,7 @@ function sp_parse_cable_tester($ip, $community, $currentTemplate) {
                 }
                 $cells.= wf_TableCell($cells_data);
                 $rows = wf_TableRow($cells, 'row3');
-                $result .= wf_TableBody($rows, '100%', 0, '');
+                $result.= wf_TableBody($rows, '100%', 0, '');
             }
         }
         return ($result);
@@ -581,6 +581,7 @@ function sp_SnmpPollDevice($ip, $community, $alltemplates, $deviceTemplate, $all
         if (!empty($currentTemplate)) {
             $deviceDescription = $currentTemplate['define']['DEVICE'];
             $deviceFdb = $currentTemplate['define']['FDB'];
+            $deviceMAC = (isset($currentTemplate['define']['MAC'])) ? $currentTemplate['define']['MAC'] : 'false';
             $sectionResult = '';
             $sectionName = '';
             $finalResult = '';
@@ -593,6 +594,13 @@ function sp_SnmpPollDevice($ip, $community, $alltemplates, $deviceTemplate, $all
                 $deviceFdbMode = $currentTemplate['define']['FDB_MODE'];
             } else {
                 $deviceFdbMode = 'default';
+            }
+
+            //selecting Device MAC processing mode
+            if (isset($currentTemplate['define']['MAC_MODE'])) {
+                $deviceMACMode = $currentTemplate['define']['MAC_MODE'];
+            } else {
+                $deviceMACMode = 'default';
             }
 
             //selecting FDB ignored port for skipping MAC-s on it
@@ -662,15 +670,15 @@ function sp_SnmpPollDevice($ip, $community, $alltemplates, $deviceTemplate, $all
 
                     if (!$quiet) {
                         if (!empty($sectionResult)) {
-                            $finalResult.=wf_tag('div', false, 'dashtask', '') . wf_tag('strong') . __($sectionName) . wf_tag('strong', true) . '<br>';
-                            $finalResult.=$sectionResult . wf_tag('div', true);
+                            $finalResult.= wf_tag('div', false, 'dashtask', '') . wf_tag('strong') . __($sectionName) . wf_tag('strong', true) . '<br>';
+                            $finalResult.= $sectionResult . wf_tag('div', true);
                         }
                     }
                 }
             }
-            $finalResult.=wf_tag('div', true);
-            $finalResult.=wf_tag('div', false, '', 'style="clear:both;"');
-            $finalResult.=wf_tag('div', true);
+            $finalResult.= wf_tag('div', true);
+            $finalResult.= wf_tag('div', false, '', 'style="clear:both;"');
+            $finalResult.= wf_tag('div', true);
             if (!$quiet) {
                 show_window('', $finalResult);
             }
@@ -799,6 +807,77 @@ function sp_SnmpPollDevice($ip, $community, $alltemplates, $deviceTemplate, $all
                         show_window(__('FDB'), wf_TableBody($rows, '100%', '0', 'sortable'));
                     }
                 }
+            }
+            //
+            //parsing data of DEVICE MAC
+            //
+                if ($deviceMAC == 'true') {
+                $MacOfDevice = '';
+                $snmp->setBackground(false); // need to process data with system + background
+
+                if ($deviceMACMode == 'default') {
+                    //default for many D-link HP JunOS
+                    $MacOfDevice = $snmp->walk($ip, $community, '.1.0.8802.1.1.2.1.3.2.0', true);
+                    print($MacOfDevice);
+                } else {
+                    /* Need Tests
+                    if ($deviceMACMode == 'dlp') {
+                        //custom dlink mac
+                        $tmpOid = '';
+                        $MacOfDevice = $snmp->walk($ip, $community, $tmpOid, true);
+                    }
+
+                    if ($deviceMACMode == 'tlp5428ev2') {
+                        $tmpOid = '';
+                        $MacOfDevice = $snmp->walk($ip, $community, $tmpOid, true);
+                    }
+
+                    if ($deviceMACMode == 'tlp2428') {
+                        $tmpOid = '';
+                        $MacOfDevice = $snmp->walk($ip, $community, $tmpOid, true);
+                    }
+
+                    if ($deviceMACMode == 'tlp2210') {
+                        $tmpOid = '';
+                        $MacOfDevice = $snmp->walk($ip, $community, $tmpOid, true);
+                    }
+
+                    //foxgate lazy parsing
+                    if ($deviceMACMode == 'flp') {
+                        $tmpOid = '';
+                        $MacOfDevice = $snmp->walk($ip, $community, $tmpOid, true);
+                    }
+                    */
+                }
+                if (!empty($MacOfDevice)) {
+                    if ($deviceMACMode == 'default') {
+                        //default M parser
+                        $MACData = sn_SnmpParseDeviceMAC($MacOfDevice);
+                    } else {
+                        /* Need test
+                        if ($deviceMACMode == 'dlp') {
+                            //exotic dlink parser
+                            $MACData = sn_SnmpParseDeviceMAC($MacOfDevice);
+                        }
+
+                        if (($deviceMACMode == 'tlp5428ev2') OR ( $deviceMACMode == 'tlp2428') OR ( $deviceMACMode == 'tlp2210')) {
+                            //more exotic tplink parser
+                            $MACData = sn_SnmpParseDeviceMAC($MacOfDevice, $tmpOid);
+                        }
+
+                        // foxgate - its you again? Oo
+                        if ($deviceMACMode == 'flp') {
+                            $MACData = sn_SnmpParseDeviceMAC($MacOfDevice, $tmpOid);
+                        }
+                        */
+                    }
+
+                    // Write Device MAC address to file
+                        if (!empty($MACData)) {
+                            file_put_contents('exports/' . $ip . '_MAC', $MACData);
+                        }
+                }
+
             }
         }
     }
@@ -963,6 +1042,28 @@ function sn_SnmpParseFdbExtract($data) {
                 $modalContent.=$each . wf_tag('br');
             }
             $result.=$each . ' ' . wf_modal(wf_img_sized('skins/menuicons/switches.png', __('Switches'), '12', '12'), __('Switches'), $modalContent, '', '600', '400');
+        }
+    }
+    return ($result);
+}
+
+/**
+ * Extracts MAC of device
+ *
+ * @param raw data $data
+ *
+ * @return string
+ */
+function sn_SnmpParseDeviceMAC($data) {
+    $result = '';
+
+    if (!empty($data)) {
+        $data = explode('=', $data);
+        $device_mac_raw = str_replace('Hex-STRING:', '', @$data[1]);
+        $device_mac_t = trim($device_mac_raw);
+        if (!empty($device_mac_t)) {
+            $device_mac = str_replace(" ", ":", $device_mac_t);
+            $result = strtolower($device_mac);
         }
     }
     return ($result);

--- a/content/.gitignore
+++ b/content/.gitignore
@@ -1,1 +1,3 @@
 *.cache.dat
+documents/wifi_cpe_sig_hist/*
+!documents/wifi_cpe_sig_hist/.htaccess

--- a/modules/general/switchpoller/index.php
+++ b/modules/general/switchpoller/index.php
@@ -164,7 +164,7 @@ if (cfr('SWITCHPOLL')) {
                                 }
                                 $deviceTemplate = $allTemplatesAssoc[$eachDevice['modelid']];
                                 $modActions = wf_BackLink('?module=switches');
-                                $modActions.= wf_Link('?module=switches&&edit=' . $switchId, web_edit_icon() . ' ' . __('Edit') . ' ' . __('Switch'), false, 'ubButton');
+                                $modActions.= wf_Link('?module=switches&edit=' . $switchId, web_edit_icon() . ' ' . __('Edit') . ' ' . __('Switch'), false, 'ubButton');
                                 $modActions.= wf_Link('?module=switchpoller&switchid=' . $eachDevice['id'] . '&forcecache=true', wf_img('skins/refresh.gif') . ' ' . __('Force query'), false, 'ubButton');
                                 show_window($deviceTemplate.' '.$eachDevice['ip'] . ' - ' . $eachDevice['location'], $modActions);
                                 sp_SnmpPollDevice($eachDevice['ip'], $eachDevice['snmp'], $allTemplates, $deviceTemplate, $allusermacs, $alladdress, $eachDevice['snmpwrite'], false);


### PR DESCRIPTION
- Модуль "Свичи" - добавлено отображение MAC устройства полученного при опросе его по SNMP.
- Модуль "Уровни сигнала на БС" - добавлена функция получения и сохранения MAC адреса .устройства для дальнейшей работы с ним в модуле "Свичи".
- Модуль "Уровни сигнала на БС" - в вывод информации об устройстве добавлен MAC устройства для Mikrotik и устройств UBNT.
- Модуль "Уровни сигнала на БС" - переработана функция возварата MAC адреса. Стала более универсальной. Можно использовать в друих местах.
- Небольшая косметика кода.

