### PR TITLE
Module REMOTE API: new asterisk call like "askozianum + [param mobilenumber]" to get user status

### DIFF
--- a/modules/general/remoteapi/index.php
+++ b/modules/general/remoteapi/index.php
@@ -999,11 +999,16 @@ if ($alterconf['REMOTEAPI_ENABLED']) {
                                     $number = trim($_GET['number']);
                                     $askNum = new AskoziaNum();
                                     $askNum->setNumber($number);
-                                    $askNum->renderReply(true);
-                                    $asterisk = new Asterisk();
-                                    $result = $asterisk->AsteriskGetInfoApi($number, $_GET['param']);
 
-                                    die($result);
+                                    if ($_GET['param'] == 'userstatus') {
+                                        $askNum->renderReply();
+                                    } else {
+                                        $askNum->renderReply(true);
+
+                                        $asterisk = new Asterisk();
+                                        $result = $asterisk->AsteriskGetInfoApi($number, $_GET['param']);
+                                        die($result);
+                                    }
                                 } else {
                                     die('ERROR: NOT HAVE PARAMETR');
                                 }


### PR DESCRIPTION
Глянь да резюмируй по свободе.

Изначально ноги у этого всего растут отсюда: http://wiki.ubilling.net.ua/doku.php?id=askoziaintro
Просто подумалось, что вот это:
//getting user state from billing API
$url = $ubillingApiUrl . '?module=remoteapi&key=' . $ubillingSerial . '&action=askozianum&param=' . $number;

неплохо было бы заменить на что-то типа:
//getting user state from billing API
$url = $ubillingApiUrl . '?module=remoteapi&key=' . $ubillingSerial . '&action=asterisk&number=' . $number . '&param=userstatus';

для тех, у кого нет <s>денег на</s> Askozia и нет надобности ее энейблить в alter.ini да и с точки зрения логики оно логичнее.

С другой стороны, я бы еще хотел, чтобы астериском озвучивалось не только состояние абона, но и его текущий баланс, например.
Но это еще надо обдумать, насколько оно нужное...