### PR TITLE
[DO NOT MERGE] TEST_PONIZER_TAB_UI

### DIFF
--- a/config/alter.ini
+++ b/config/alter.ini
@@ -777,3 +777,5 @@ DEVICES_LISTS_SORT_BY_MODELNAME=0
 ;TASKMAN_SHOW_ALL_YEARS_TASKS=0
 ;Is comparison by tariff mask for displaying CPE controls in user's profile case sensitive?
 ;USERCPE_TARIFFMASK_CASEINSENS=0
+;Use tabs for OLTs representation in PONizer
+;PON_UI_USE_TABS=0


### PR DESCRIPTION
Флай, посмотри по свободе/возможности где-то в тестовом режиме. 
Если зайдет такой вариант - нужно будет следующее:
 - решить, оставляем jquery UI или таки юзаем Вуй
 - если оставляем jquery UI - нужно будет прикручивать плагин для горизонтального 
   прокручивания/листания вкладок, если они не помещаются внутри контейнера, чтобы 
   они не складировались "штабелями" как в jquery UI Tabs сделано по дефолту, 
   ибо выглядит это, мягко говоря, не очень
 - в любом случае, если таки зайдет - надо продумать и реализовать re-usable компоненты
   для этого всего в api.astral (кстати, компоненты для Вуя тоже там будут "жить"?)
Если же не зайдет... - жаль, кмк, юзабилити с табами повышается...