### PR TITLE
signal_coloring_rearrangement

### DIFF
--- a/api/libs/api.pon.php
+++ b/api/libs/api.pon.php
@@ -4138,6 +4138,39 @@ class PONizer {
         return ($result);
     }
 
+
+    /**
+     * Returns array like: $userLogin => $onuSignal
+     *
+     * @return array
+     */
+    public static function getAllONUSignals() {
+        $allOnuSignals = array();
+        $signalCache = array();
+        $availCacheData = rcms_scandir(self::SIGCACHE_PATH, '*_' . self::SIGCACHE_EXT);
+
+        $query = "SELECT * from `pononu`";
+        $allOnuRecs = simple_queryall($query);
+
+        if (!empty($allOnuRecs) and !empty($availCacheData)) {
+            foreach ($availCacheData as $io => $each) {
+                $raw = file_get_contents(self::SIGCACHE_PATH . $each);
+                $raw = unserialize($raw);
+
+                foreach ($raw as $mac => $signal) {
+                    $signalCache[$mac] = $signal;
+                }
+            }
+
+            foreach ($allOnuRecs as $io => $each) {
+                if (isset($signalCache[$each['mac']])) {
+                    $allOnuSignals[$each['login']] = $signalCache[$each['mac']];
+                }
+            }
+        }
+
+        return ($allOnuSignals);
+    }
 }
 
 class PONizerLegacy extends PONizer {

--- a/api/libs/api.userprofile.php
+++ b/api/libs/api.userprofile.php
@@ -903,11 +903,14 @@ class UserProfile {
                         $raw = unserialize($raw);
                         foreach ($raw as $mac => $signal) {
                             if ($mac == $onu_data['mac'] or $mac == $onu_data['serial']) {
-                                if (($signal > 0) OR ( $signal < -25)) {
+                                if (($signal > 0) OR ( $signal < -27)) {
                                     $sigColor = '#ab0000';
+                                } elseif ($signal > -27 AND $signal < -25) {
+                                    $sigColor = '#FF5500';
                                 } else {
                                     $sigColor = '#005502';
                                 }
+
                                 $searched = $signal;
                             }
                         }

--- a/config/alter.ini
+++ b/config/alter.ini
@@ -875,3 +875,9 @@ DREAMKAS_AUTH_TOKEN=
 ;TOUCH_FIX=1
 ;Optional option. Describes ONU devices MAC address which will be hidden from "unknown list". Coma - delimiter.
 ;PON_ONU_HIDE=""
+;Hides all picts title text in online table, like "Yes", "No" and "Freezed"
+;ONLINE_HIDE_PICT_TITLES=0
+;Show PON signal levels in online table. Might significantly affect overall performance.
+;ONLINE_SHOW_ONU_SIGNALS=0
+;Show WiFi CPE signal levels in online table. Might significantly affect overall performance.
+;ONLINE_SHOW_WIFI_SIGNALS=0


### PR DESCRIPTION
Module Online: added ability to show ONU signals and WiFi CPE signals. This can be regulated by two separate non-mandatory alter.ini options.
alter.ini: two new options ONLINE_SHOW_ONU_SIGNALS and ONLINE_SHOW_WIFI_SIGNALS to control the visibility of the related columns in Online table and one new option ONLINE_HIDE_PICT_TITLES to hide all the text like "Yes", "No" and "Freezed" from Online table

Slightly rearranged the coloring of the PON and WiFi signals to make it more unified across the modules