### PR TITLE
different_stuff_together

### DIFF
--- a/api/libs/api.astral.php
+++ b/api/libs/api.astral.php
@@ -1377,9 +1377,41 @@ function wf_DatePickerPreset($field, $date, $extControls = false, $CtrlID = '', 
  * @return string
  *  
  */
-function wf_FullCalendar($data, $options = '') {
-
+function wf_FullCalendar($data, $options = '', $useHTMLInTitle = false, $useHTMLListViewOnly = false) {
     $elementid = wf_InputId();
+
+    if ($useHTMLInTitle) {
+        if ($useHTMLListViewOnly) {
+            $htmlInTitle = " eventRender: function(event, element, view) {
+                                if (view.type.indexOf('list') >= 0) {
+                                    var link = element.find('[class*=-title] a');
+                                    var title = element.find('[class*=-title]');
+                                    link.html(title.text());
+                                    title.html( link );
+                                } else {                                    
+                                    var title = element.find('[class*=-title]');
+                                    // some hack to remove HTML from text
+                                    var doc = new DOMParser().parseFromString(title.text(), 'text/html');
+                                    var titleText = (doc.body.textContent || \"\");
+                                    title.html( titleText );
+                                }
+                            }, ";
+        } else {
+            $htmlInTitle = " eventRender: function(event, element, view) {
+                                if (view.type.indexOf('list') >= 0) {
+                                    var link = element.find('[class*=-title] a');
+                                    var title = element.find('[class*=-title]');
+                                    link.html(title.text());
+                                    title.html( link );
+                                } else {
+                                    var title = element.find('[class*=-title]');
+                                    title.html( title.text() );
+                                }
+                            }, ";
+        }
+    } else {
+        $htmlInTitle = '';
+    }
 
     $calendar = "<script type='text/javascript'>
 
@@ -1398,6 +1430,7 @@ function wf_FullCalendar($data, $options = '') {
 			},
                         
 			editable: false,
+                        " . $htmlInTitle . "                         
                         theme: true,
                         weekends: true,
                         timeFormat: 'H(:mm)',

--- a/api/libs/api.dreamkas.php
+++ b/api/libs/api.dreamkas.php
@@ -1126,7 +1126,7 @@ class DreamKas {
                 foreach ($fopsData as $eachFiscOp) {
                     $fiscopID = $eachFiscOp['id'];
                     $fiscopStatus = $eachFiscOp['status'];
-                    $fiscopDateFinish = $eachFiscOp['completedAt'];
+                    $fiscopDateFinish = (empty($eachFiscOp['completedAt'])) ? '0000-00-00 00:00:00' : date('Y-m-d H:i:s', strtotime($eachFiscOp['completedAt']));
                     $fiscopErrorCode = (isset($eachFiscOp['data']['error']['code'])) ? $eachFiscOp['data']['error']['code'] : '';
                     $fiscopErrorMsg = (isset($eachFiscOp['data']['error']['message'])) ? $eachFiscOp['data']['error']['message'] : '';
                     $fiscopReceiptID = (isset($eachFiscOp['data']['receiptId'])) ? $eachFiscOp['data']['receiptId'] : '';
@@ -1134,7 +1134,7 @@ class DreamKas {
                     if (isset($fopsDataLocal[$fiscopID])) {
                         $tQuery = "UPDATE `dreamkas_operations` SET 
                                       `status` = '" . $fiscopStatus . "', 
-                                      `date_finish` = '" . date('Y-m-d H:i:s', strtotime($fiscopDateFinish)) . "',
+                                      `date_finish` = '" . $fiscopDateFinish . "',
                                       `error_code` = '" . $fiscopErrorCode . "',
                                       `error_message` = '" . $fiscopErrorMsg . "',
                                       `receipt_id` = '" . $fiscopReceiptID . "'

--- a/api/libs/api.taskman.php
+++ b/api/libs/api.taskman.php
@@ -679,6 +679,8 @@ function ts_JGetDoneTasks() {
     global $ubillingConfig;
     $altCfg = $ubillingConfig->getAlter();
     $showAllYearsTasks = $ubillingConfig->getAlterParam('TASKMAN_SHOW_ALL_YEARS_TASKS');
+    $showExtendedDone = $ubillingConfig->getAlterParam('TASKMAN_SHOW_DONE_EXTENDED');
+    $extendedDoneAlterStyling = $ubillingConfig->getAlterParam('TASKMAN_DONE_EXTENDED_ALTERSTYLING');
 
     //ADcomments init
     if ($altCfg['ADCOMMENTS_ENABLED']) {
@@ -688,7 +690,9 @@ function ts_JGetDoneTasks() {
         $adcFlag = false;
     }
     $allemployee = ts_GetAllEmployee();
-    $alljobtypes = ts_GetAllJobtypes();
+
+    // unnecessary call - isn't it?
+    //$alljobtypes = ts_GetAllJobtypes();
 
     $curyear = curyear();
     $curmonth = date("m");
@@ -753,9 +757,30 @@ function ts_JGetDoneTasks() {
                 $adcText = '';
             }
 
+            $doneemploee = (!empty($allemployee[$eachtask['employeedone']])) ? $allemployee[$eachtask['employeedone']] : '';
+
+            if ($showExtendedDone) {
+                if ($extendedDoneAlterStyling) {
+                    $jobtype = (!empty($eachtask['jobname'])) ? ' - <span style="color: #1d1ab2;"><b>' . __('Job type') . ': </b></span>' . $eachtask['jobname'] : '';
+                    $jobnote = (!empty($eachtask['jobnote'])) ? ' - <span style="color: #1d1ab2;"><b>' . __('Job note') . ': </b></span>' . $eachtask['jobnote'] : '';
+                    $donenote = (!empty($eachtask['donenote'])) ? ' - <span style="color: #1d1ab2;"><b>' . __('Finish note') . ': </b></span>' . $eachtask['donenote'] : '';
+                    $donedate = (!empty($eachtask['enddate'])) ? ' - <span style="color: #1d1ab2;"><b>' . __('Finish date') . ': </b></span>' . $eachtask['enddate'] : '';
+
+                    $doneemploee = (!empty($allemployee[$eachtask['employeedone']])) ? '<b>' . $allemployee[$eachtask['employeedone']] . '</b>'  : '';
+                } else {
+                    $jobtype = (!empty($eachtask['jobname'])) ? ' - ' . __('Job type') . ': ' . $eachtask['jobname'] : '';
+                    $jobnote = (!empty($eachtask['jobnote'])) ? ' - ' . __('Job note') . ': ' . $eachtask['jobnote'] : '';
+                    $donenote = (!empty($eachtask['donenote'])) ? ' - ' . __('Finish note') . ': ' . $eachtask['donenote'] : '';
+                    $donedate = (!empty($eachtask['enddate'])) ? ' - ' . __('Finish date') . ': ' . $eachtask['enddate'] : '';
+                }
+                $extendInfo = $jobtype . $jobnote . $donenote . $donedate;
+            } else {
+                $extendInfo = '';
+            }
+
             $result .= "
                       {
-                        title: '" . $eachtask['address'] . " - " . @$allemployee[$eachtask['employeedone']] . $adcText . "',
+                        title: '" . $eachtask['address'] . " - " . $doneemploee . $adcText . mysql_real_escape_string($extendInfo) . "',
                         start: new Date(" . $startdate . "),
                         end: new Date(" . $enddate . "),
                         url: '?module=taskman&edittask=" . $eachtask['id'] . "'

--- a/api/libs/api.userdata.php
+++ b/api/libs/api.userdata.php
@@ -174,6 +174,9 @@ function zb_UserGetAllData($login = '') {
     } else {
         $query.= "concat(`streetname`, ' ', `buildnum`, '/', `apt`) AS `fulladress`,";
     }
+
+    if ($altCfg['MOBILES_EXT']) { $query.= " `mobext`.`mobiles`, "; }
+
     $query.= "
                     `phones`.`phone`,`mobile`,`contract`,`emails`.`email`
                     FROM `users` LEFT JOIN `nethosts` USING (`ip`)
@@ -185,9 +188,17 @@ function zb_UserGetAllData($login = '') {
                     LEFT JOIN `city` ON (`street`.`cityid`=`city`.`id`)
                     LEFT JOIN `phones` ON (`users`.`login`=`phones`.`login`)
                     LEFT JOIN `contracts` ON (`users`.`login`=`contracts`.`login`)
-                    LEFT JOIN `emails` ON (`users`.`login`=`emails`.`login`)
-                    " . $query_wh;
+                    LEFT JOIN `emails` ON (`users`.`login`=`emails`.`login`) ";
+
+    if ($altCfg['MOBILES_EXT']) {
+        $query.= "LEFT JOIN (SELECT `mobileext`.`login`, GROUP_CONCAT(`mobile` SEPARATOR ' ') as `mobiles` FROM `mobileext` GROUP BY `login`) `mobext` 
+                    ON (`users`.`login` = `mobext`.`login`) ";
+    }
+
+    $query.= $query_wh;
+
     $Alldata = (!empty($login)) ? simple_query($query) : simple_queryall($query);
+
     if (empty($login) and ! empty($Alldata)) {
         foreach ($Alldata as $data) {
             $result[$data['login']] = $data;

--- a/config/alter.ini
+++ b/config/alter.ini
@@ -891,3 +891,18 @@ UNIVERSAL_QINQ_ENABLED=0
 ONUREG_QINQ_ENABLED=0
 ;Enables IBAN labels instead bank account.
 IBAN_ENABLED=0
+;path to your asterisk call recording dir
+;ASTERISK_CALLRECS_PATH="/var/spool/asterisk/monitor/"
+;Specify CEL tab name and use CEL tab to determine recordings path more precisely
+;ASTERISK_CALLRECS_CEL_TAB_NAME=""
+;file extension of your asterisk call recordings. leave blank to consider all files in place
+;ASTERISK_CALLRECS_FORMAT=""
+;show last fee charge column in online tab. extremely vsratyi shit, kurwa. use at your own risk and with HP_MODE=1 ONLY.
+;"stgfeecharge2mysql" RemoteAPI call needed for this shit to work properly
+;ONLINE_SHOW_LAST_FEECHARGE=0
+;show all phone numbers assigned to user in online tab
+;ONLINE_SHOW_PHONES=0
+;show some extended info for done tasks
+;TASKMAN_SHOW_DONE_EXTENDED=0
+;alternate styling of the extended info for done tasks
+;TASKMAN_DONE_EXTENDED_ALTERSTYLING=0

--- a/languages/russian/billing.php
+++ b/languages/russian/billing.php
@@ -3103,6 +3103,8 @@ $lang['def']['Processed calls'] = 'Обработанные звонки';
 $lang['def']['Call me back'] = 'Перезвоните мне пожалуйста';
 $lang['def']['right to manage callmeback module '] = 'Право управлять модулем коллбэка';
 $lang['def']['upper case'] = 'верхний регистр';
+$lang['def']['Call recording'] = 'Запись разговора';
+$lang['def']['Last fee charge'] = 'Последнее списание средств';
 $lang['def'][''] = '';
 
 

--- a/languages/ukrainian/billing.php
+++ b/languages/ukrainian/billing.php
@@ -3120,5 +3120,6 @@ $lang['def']['Processed calls'] = 'Опрацьовані дзвінки';
 $lang['def']['Call me back'] = 'Перетелефонуйте мені будь ласка';
 $lang['def']['right to manage callmeback module '] = 'Право керувати модулем коллбеку';
 $lang['def']['upper case'] = 'верхній регістр';
-
+$lang['def']['Call recording'] = 'Запис размови';
+$lang['def']['Last fee charge'] = 'Останнє списання коштів';
 ?>

--- a/modules/general/online/index.php
+++ b/modules/general/online/index.php
@@ -27,6 +27,11 @@ if ($system->checkForRight('ONLINE')) {
             $ShowContractField = true;
         }
 
+        $showUserPhones = false;
+        if (isset($alter_conf['ONLINE_SHOW_PHONES']) && $alter_conf['ONLINE_SHOW_PHONES']) {
+            $showUserPhones = true;
+        }
+
         $columnDefs = '';
         $showONUSignals = false;
         $showWIFISignals = false;
@@ -34,7 +39,7 @@ if ($system->checkForRight('ONLINE')) {
         if (isset($alter_conf['PON_ENABLED']) && $alter_conf['PON_ENABLED'] &&
             isset($alter_conf['ONLINE_SHOW_ONU_SIGNALS']) && $alter_conf['ONLINE_SHOW_ONU_SIGNALS']) {
             $showONUSignals = true;
-            $colNum1 = ($ShowContractField) ? '4' : '3';
+            $colNum1 = (($ShowContractField and $showUserPhones) ? '5' : (($ShowContractField xor $showUserPhones) ? '4' : '3'));
 
             $columnDefs.= '{"targets": ' . $colNum1 . ',
                                 "render": function ( data, type, row ) {                                          
@@ -56,7 +61,11 @@ if ($system->checkForRight('ONLINE')) {
         if (isset($alter_conf['MTSIGMON_ENABLED']) && $alter_conf['MTSIGMON_ENABLED'] &&
             isset($alter_conf['ONLINE_SHOW_WIFI_SIGNALS']) && $alter_conf['ONLINE_SHOW_WIFI_SIGNALS']) {
             $showWIFISignals = true;
-            $colNum2 = (($ShowContractField and $showONUSignals) ? '5' : ((!$ShowContractField and !$showONUSignals) ? '3' : '4'));
+
+            // fuckin' XOR magic goes below this line. don't touch it(especially the parentheses) or you'll be cursed with hours of debugging
+            $colNum2 = (($ShowContractField and $showUserPhones and $showONUSignals) ? '6' :
+                        ((($ShowContractField and $showUserPhones) xor ($showUserPhones and $showONUSignals) xor ($ShowContractField and $showONUSignals)) ? '5' :
+                        (($ShowContractField xor $showUserPhones xor $showONUSignals) ? '4' : '3')));
 
             $columnDefs.= (empty($columnDefs) ? '' : ', ');
             $columnDefs.= '{"targets": ' . $colNum2 . ',
@@ -85,6 +94,11 @@ if ($system->checkForRight('ONLINE')) {
                             }, ';
         }
 
+        $showLastFeeCharge = false;
+        if (isset($alter_conf['ONLINE_SHOW_LAST_FEECHARGE']) && $alter_conf['ONLINE_SHOW_LAST_FEECHARGE']) {
+            $showLastFeeCharge = true;
+        }
+
         $columnDefs = '"columnDefs": [ ' . $columnDefs . '], ';
 
         //alternate center styling
@@ -99,8 +113,9 @@ if ($system->checkForRight('ONLINE')) {
             $columnFilters = '
              null, ' .
                     ( ($hp_mode == 1 && $ShowContractField) ? 'null,' : '' ) .
-                    ' null,
-                { "sType": "ip-address" }, ' .
+                    ' null, ' .
+                ( ($hp_mode == 1 && $showUserPhones) ? 'null,' : '' ) .
+                ' { "sType": "ip-address" }, ' .
                 ( ($hp_mode == 1 && $showONUSignals) ? 'null, ' : '' ) .
                 ( ($hp_mode == 1 && $showWIFISignals) ? 'null, ' : '' ) .
                 ' null,
@@ -108,22 +123,23 @@ if ($system->checkForRight('ONLINE')) {
                 null,
                 { "sType": "file-size" },
                 null,
-                null
-            ';
+                null ' .
+                ( ($hp_mode == 1 && $showLastFeeCharge) ? ', null' : '' );
         } else {
             $columnFilters = '
              null, ' .
                     ( ($hp_mode == 1 && $ShowContractField) ? 'null,' : '' ) .
-                    ' null,
-                { "sType": "ip-address" }, ' .
+                    ' null, ' .
+                ( ($hp_mode == 1 && $showUserPhones) ? 'null,' : '' ) .
+                ' { "sType": "ip-address" }, ' .
                 ( ($hp_mode == 1 && $showONUSignals) ? 'null, ' : '' ) .
                 ( ($hp_mode == 1 && $showWIFISignals) ? 'null, ' : '' ) .
                 ' null,
                 null,
                 { "sType": "file-size" },
-                null,
-                null
-            ';
+                null,                
+                null ' .
+                ( ($hp_mode == 1 && $showLastFeeCharge) ? ', null' : '' );
         }
 
         $dtcode = '
@@ -269,6 +285,7 @@ if ($system->checkForRight('ONLINE')) {
         $result.= wf_TableCell(__('Full address'));
         $result.= ( ($hp_mode == 1 && $ShowContractField) ? wf_TableCell(__('Contract')) : '' );
         $result.= wf_TableCell(__('Real Name'));
+        $result.= ( ($hp_mode == 1 && $showUserPhones) ? wf_TableCell(__("Phones")) : '' );
         $result.= wf_TableCell(__('IP'));
         $result.= ( ($hp_mode == 1 && $showONUSignals) ? wf_TableCell(__("ONU Signal")) : '' );
         $result.= ( ($hp_mode == 1 && $showWIFISignals) ? wf_TableCell(__("Signal") . ' WiFi') : '' );
@@ -278,6 +295,7 @@ if ($system->checkForRight('ONLINE')) {
         $result.= wf_TableCell(__('Traffic'));
         $result.= wf_TableCell(__('Balance'));
         $result.= wf_TableCell(__('Credit'));
+        $result.= ( ($hp_mode == 1 && $showLastFeeCharge) ? wf_TableCell(__("Last fee charge")) : '' );
         $result.= wf_tag('tr', true);
         $result.= wf_tag('thead', true);
         $result.= wf_tag('table', true);
@@ -296,6 +314,7 @@ if ($system->checkForRight('ONLINE')) {
      */
     function zb_AjaxOnlineDataSourceSafe() {
         global $alter_conf;
+        $ubCache = new UbillingCache();
         $ishimuraOption = MultiGen::OPTION_ISHIMURA;
         $ishimuraTable = MultiGen::NAS_ISHIMURA;
         $additionalTraffic = array();
@@ -393,6 +412,34 @@ if ($system->checkForRight('ONLINE')) {
             $allWiFiSignals = $WiFiSigmon->getAllWiFiSignals();
         }
 
+        $allFees = array();
+        $showLastFeeCharge = false;
+        if (isset($alter_conf['ONLINE_SHOW_LAST_FEECHARGE']) && $alter_conf['ONLINE_SHOW_LAST_FEECHARGE']) {
+            $showLastFeeCharge = true;
+            $allFees = $ubCache->get('STG_FEE_CHARGE');
+        }
+
+        $showUserPhones = false;
+        $allUserPhones = array();
+        if (isset($alter_conf['ONLINE_SHOW_PHONES']) && $alter_conf['ONLINE_SHOW_PHONES']) {
+            $showUserPhones = true;
+            $allUserDataCached = zb_UserGetAllDataCache();
+
+            if (!empty($allUserDataCached)) {
+                foreach ($allUserDataCached as $eachLogin => $eachData) {
+                    $userPhones = (empty($eachData['phone'])) ? '' : str_ireplace(array('+', "-"), '', $eachData['phone']) . ' ';
+                    $userPhones.= (empty($eachData['mobile'])) ? '' : str_ireplace(array('+', "-"), '', $eachData['mobile']);
+                    $userPhones.= (empty($eachData['mobiles'])) ? '' : '<br />' . str_ireplace(array('+', "-"), '', $eachData['mobiles']);
+
+                    if (!empty($userPhones)) {
+                        $allUserPhones[$eachLogin] = $userPhones;
+                    }
+                }
+            }
+
+            unset($allUserDataCached);
+        }
+
         $query = "SELECT * FROM `users`";
         $query_fio = "SELECT * from `realname`";
         $allusers = simple_queryall($query);
@@ -479,6 +526,8 @@ if ($system->checkForRight('ONLINE')) {
 
                 $onuSignal = '';
                 $wifiSignal = '';
+                $feeCharge = '';
+                $userPhones = '';
 
                 if ($showONUSignals and isset($allONUSignals[$eachuser['login']])) {
                     $onuSignal = $allONUSignals[$eachuser['login']];
@@ -488,15 +537,28 @@ if ($system->checkForRight('ONLINE')) {
                     $wifiSignal = $allWiFiSignals[$eachuser['login']];
                 }
 
+                if ($showLastFeeCharge and isset($allFees[$eachuser['login']])) {
+                    $feeCharge = $allFees[$eachuser['login']]['max_date'] . '<br />' . ($allFees[$eachuser['login']]['balance_to'] - $allFees[$eachuser['login']]['balance_from']);
+                }
+
+                if ($showUserPhones and isset($allUserPhones[$eachuser['login']])) {
+                    $userPhones = $allUserPhones[$eachuser['login']];
+                }
+
                 if (!$alter_conf['DEAD_HIDE']) {
                     $jsonItem = array();
                     $jsonItem[] = '<a href=?module=traffstats&username=' . $eachuser['login'] . '><img src=skins/icon_stats.gif border=0 title=' . __('Stats') . '></a> <a href=?module=userprofile&username=' . $eachuser['login'] . '><img src=skins/icon_user.gif border=0 title=' . __('Profile') . '></a> ' . $fastcashlink . $addrDelimiter . $clearuseraddress;
 
                     if ($ShowContractField) {
-                        $jsonItem[] = @$allcontracts[$eachuser['login']] . ( ($ShowContractDate) ? wf_tag('br') . @$allcontractdates[$eachuser['login']] : '' );
+                        $jsonItem[] = @$allcontracts[$eachuser['login']] . (($ShowContractDate) ? wf_tag('br') . @$allcontractdates[$eachuser['login']] : '');
                     }
 
                     $jsonItem[] = @$fioz[$eachuser['login']] . (($showUserNotes and isset($allUserNotes[$eachuser['login']]['note'])) ? wf_delimiter(0) . '( ' . $allUserNotes[$eachuser['login']]['note'] . ' )' . $allUserNotes[$eachuser['login']]['adcomment'] : '');
+
+                    if ($showUserPhones) {
+                        $jsonItem[] = $userPhones;
+                    }
+
                     $jsonItem[] = $eachuser['IP'];
 
                     if ($showONUSignals) {
@@ -515,6 +577,11 @@ if ($system->checkForRight('ONLINE')) {
                     $jsonItem[] = zb_TraffToGb($tinet);
                     $jsonItem[] = "" . round($eachuser['Cash'], 2);
                     $jsonItem[] = "" . round($eachuser['Credit'], 2);
+
+                    if ($showLastFeeCharge) {
+                        $jsonItem[] = $feeCharge;
+                    }
+
                     $jsonAAData[] = $jsonItem;
                 } else {
                     if (!isset($deadUsers[$eachuser['login']])) {
@@ -526,6 +593,11 @@ if ($system->checkForRight('ONLINE')) {
                         }
 
                         $jsonItem[] = @$fioz[$eachuser['login']] . (($showUserNotes and isset($allUserNotes[$eachuser['login']]['note'])) ? wf_delimiter(0) . '( ' . $allUserNotes[$eachuser['login']]['note'] . ' )' . $allUserNotes[$eachuser['login']]['adcomment'] : '');
+
+                        if ($showUserPhones) {
+                            $jsonItem[] = $userPhones;
+                        }
+
                         $jsonItem[] = $eachuser['IP'];
 
                         if ($showONUSignals) {
@@ -544,6 +616,11 @@ if ($system->checkForRight('ONLINE')) {
                         $jsonItem[] = zb_TraffToGb($tinet);
                         $jsonItem[] = "" . round($eachuser['Cash'], 2);
                         $jsonItem[] = "" . round($eachuser['Credit'], 2);
+
+                        if ($showLastFeeCharge) {
+                            $jsonItem[] = $feeCharge;
+                        }
+
                         $jsonAAData[] = $jsonItem;
                     }
                 }

--- a/modules/general/taskman/index.php
+++ b/modules/general/taskman/index.php
@@ -138,10 +138,17 @@ if (cfr('TASKMAN')) {
                         // Task logs
                         show_window(__('View log'), ts_renderLogsListAjax());
                     } else {
+                        $showExtendedDone = $ubillingConfig->getAlterParam('TASKMAN_SHOW_DONE_EXTENDED');
+                        $extendedDoneAlterStyling = $ubillingConfig->getAlterParam('TASKMAN_DONE_EXTENDED_ALTERSTYLING');
+                        $extendedDoneAlterStylingBool = ($extendedDoneAlterStyling > 0);
+                        $extendedDoneAlterListOnly = ($extendedDoneAlterStylingBool and $extendedDoneAlterStyling == 2);
+
                         //custom jobtypes color styling
                         $customJobColorStyle = ts_GetAllJobtypesColorStyles();
                         //show full calendar view
-                        show_window('', $customJobColorStyle . wf_FullCalendar($showtasks, $fullCalendarOpts));
+                        show_window('', $customJobColorStyle . wf_FullCalendar($showtasks, $fullCalendarOpts,
+                                                                               $extendedDoneAlterStylingBool,
+                                                                               $extendedDoneAlterListOnly));
                     }
                 } else {
                     show_window(__('Show late'), ts_ShowLate());


### PR DESCRIPTION
New alter.ini non-mandatory options:
;ASTERISK_CALLRECS_PATH="/var/spool/asterisk/monitor/"
;ASTERISK_CALLRECS_CEL_TAB_NAME=""
;ASTERISK_CALLRECS_FORMAT=""
;ONLINE_SHOW_LAST_FEECHARGE=0
;ONLINE_SHOW_PHONES=0
;TASKMAN_SHOW_DONE_EXTENDED=0
;TASKMAN_DONE_EXTENDED_ALTERSTYLING=0

Module Asterisk PBX: from now on can show and play and download call recordings. But that's not for sure yet(needs additional tests&reports).
Module Dreamkas: fiscal operations displaying bugfixed
Module Online: 
	from now on can display subscriber's phones(all phones, including ext mobiles). Only with HP_MODE=1.
	from now on has an extremely vsratuyu bullshitty ability to display "last fee charge". ONLY with HP_MODE=1. 
	    Can awfully slow down the rendering of "Online table" and GUI in general.
            to work correctly it demands SEPARATE(!) RemoteAPI call to fullfill it's cache with data from stargazer.log
	        don't ask me "For what?"	            
 	       don't ask me "Why?"
                just think twice, don't forgot
	        or your system will cry

Module Taskman: from now on can display extended info for done task and to separate the displayin for different views. 
api.astral: from now on you can use HTML in events titles for a fullcalendar widget. This ability is controlled by 2 additional parameters.

It's so vsratyi gathered PR. I hope it won't blow anything up and no one would have the feeling of "BAMBANULO"...