### PR TITLE
aster_pbx_call_recs

### DIFF
--- a/api/libs/api.dreamkas.php
+++ b/api/libs/api.dreamkas.php
@@ -1126,7 +1126,7 @@ class DreamKas {
                 foreach ($fopsData as $eachFiscOp) {
                     $fiscopID = $eachFiscOp['id'];
                     $fiscopStatus = $eachFiscOp['status'];
-                    $fiscopDateFinish = $eachFiscOp['completedAt'];
+                    $fiscopDateFinish = (empty($eachFiscOp['completedAt'])) ? '0000-00-00 00:00:00' : date('Y-m-d H:i:s', strtotime($eachFiscOp['completedAt']));
                     $fiscopErrorCode = (isset($eachFiscOp['data']['error']['code'])) ? $eachFiscOp['data']['error']['code'] : '';
                     $fiscopErrorMsg = (isset($eachFiscOp['data']['error']['message'])) ? $eachFiscOp['data']['error']['message'] : '';
                     $fiscopReceiptID = (isset($eachFiscOp['data']['receiptId'])) ? $eachFiscOp['data']['receiptId'] : '';
@@ -1134,7 +1134,7 @@ class DreamKas {
                     if (isset($fopsDataLocal[$fiscopID])) {
                         $tQuery = "UPDATE `dreamkas_operations` SET 
                                       `status` = '" . $fiscopStatus . "', 
-                                      `date_finish` = '" . date('Y-m-d H:i:s', strtotime($fiscopDateFinish)) . "',
+                                      `date_finish` = '" . $fiscopDateFinish . "',
                                       `error_code` = '" . $fiscopErrorCode . "',
                                       `error_message` = '" . $fiscopErrorMsg . "',
                                       `receipt_id` = '" . $fiscopReceiptID . "'

--- a/config/alter.ini
+++ b/config/alter.ini
@@ -891,3 +891,9 @@ UNIVERSAL_QINQ_ENABLED=0
 ONUREG_QINQ_ENABLED=0
 ;Enables IBAN labels instead bank account.
 IBAN_ENABLED=0
+;path to your asterisk call recording dir
+;ASTERISK_CALLRECS_PATH="/var/spool/asterisk/monitor/"
+;Specify CEL tab name and use CEL tab to determine recordings path more precisely
+;ASTERISK_CALLRECS_CEL_TAB_NAME=""
+;file extension of your asterisk call recordings. leave blank to consider all files in place
+;ASTERISK_CALLRECS_FORMAT=""

--- a/languages/russian/billing.php
+++ b/languages/russian/billing.php
@@ -3103,6 +3103,8 @@ $lang['def']['Processed calls'] = 'Обработанные звонки';
 $lang['def']['Call me back'] = 'Перезвоните мне пожалуйста';
 $lang['def']['right to manage callmeback module '] = 'Право управлять модулем коллбэка';
 $lang['def']['upper case'] = 'верхний регистр';
+$lang['def']['Call recording'] = 'Запись разговора';
+$lang['def']['Last fee charge'] = 'Последнее списание средств';
 $lang['def'][''] = '';
 
 

--- a/languages/ukrainian/billing.php
+++ b/languages/ukrainian/billing.php
@@ -3120,5 +3120,6 @@ $lang['def']['Processed calls'] = 'Опрацьовані дзвінки';
 $lang['def']['Call me back'] = 'Перетелефонуйте мені будь ласка';
 $lang['def']['right to manage callmeback module '] = 'Право керувати модулем коллбеку';
 $lang['def']['upper case'] = 'верхній регістр';
-
+$lang['def']['Call recording'] = 'Запис размови';
+$lang['def']['Last fee charge'] = 'Останнє списання коштів';
 ?>


### PR DESCRIPTION
New alter.ini non-mandatory options:
;ASTERISK_CALLRECS_PATH="/var/spool/asterisk/monitor/"
;ASTERISK_CALLRECS_CEL_TAB_NAME=""

Module Asterisk PBX: from now on can show and play and download call recordings. But that's not for sure yet(needs additional tests&reports).
Module Dreamkas: fiscal operations displaying bugfixed