### PR TITLE
taskman_done_extended

### DIFF
--- a/api/libs/api.astral.php
+++ b/api/libs/api.astral.php
@@ -1377,9 +1377,41 @@ function wf_DatePickerPreset($field, $date, $extControls = false, $CtrlID = '', 
  * @return string
  *  
  */
-function wf_FullCalendar($data, $options = '') {
-
+function wf_FullCalendar($data, $options = '', $useHTMLInTitle = false, $useHTMLListViewOnly = false) {
     $elementid = wf_InputId();
+
+    if ($useHTMLInTitle) {
+        if ($useHTMLListViewOnly) {
+            $htmlInTitle = " eventRender: function(event, element, view) {
+                                if (view.type.indexOf('list') >= 0) {
+                                    var link = element.find('[class*=-title] a');
+                                    var title = element.find('[class*=-title]');
+                                    link.html(title.text());
+                                    title.html( link );
+                                } else {                                    
+                                    var title = element.find('[class*=-title]');
+                                    // some hack to remove HTML from text
+                                    var doc = new DOMParser().parseFromString(title.text(), 'text/html');
+                                    var titleText = (doc.body.textContent || \"\");
+                                    title.html( titleText );
+                                }
+                            }, ";
+        } else {
+            $htmlInTitle = " eventRender: function(event, element, view) {
+                                if (view.type.indexOf('list') >= 0) {
+                                    var link = element.find('[class*=-title] a');
+                                    var title = element.find('[class*=-title]');
+                                    link.html(title.text());
+                                    title.html( link );
+                                } else {
+                                    var title = element.find('[class*=-title]');
+                                    title.html( title.text() );
+                                }
+                            }, ";
+        }
+    } else {
+        $htmlInTitle = '';
+    }
 
     $calendar = "<script type='text/javascript'>
 
@@ -1398,6 +1430,7 @@ function wf_FullCalendar($data, $options = '') {
 			},
                         
 			editable: false,
+                        " . $htmlInTitle . "                         
                         theme: true,
                         weekends: true,
                         timeFormat: 'H(:mm)',

--- a/api/libs/api.taskman.php
+++ b/api/libs/api.taskman.php
@@ -679,6 +679,8 @@ function ts_JGetDoneTasks() {
     global $ubillingConfig;
     $altCfg = $ubillingConfig->getAlter();
     $showAllYearsTasks = $ubillingConfig->getAlterParam('TASKMAN_SHOW_ALL_YEARS_TASKS');
+    $showExtendedDone = $ubillingConfig->getAlterParam('TASKMAN_SHOW_DONE_EXTENDED');
+    $extendedDoneAlterStyling = $ubillingConfig->getAlterParam('TASKMAN_DONE_EXTENDED_ALTERSTYLING');
 
     //ADcomments init
     if ($altCfg['ADCOMMENTS_ENABLED']) {
@@ -688,7 +690,9 @@ function ts_JGetDoneTasks() {
         $adcFlag = false;
     }
     $allemployee = ts_GetAllEmployee();
-    $alljobtypes = ts_GetAllJobtypes();
+
+    // unnecessary call - isn't it?
+    //$alljobtypes = ts_GetAllJobtypes();
 
     $curyear = curyear();
     $curmonth = date("m");
@@ -753,9 +757,30 @@ function ts_JGetDoneTasks() {
                 $adcText = '';
             }
 
+            $doneemploee = (!empty($allemployee[$eachtask['employeedone']])) ? $allemployee[$eachtask['employeedone']] : '';
+
+            if ($showExtendedDone) {
+                if ($extendedDoneAlterStyling) {
+                    $jobtype = (!empty($eachtask['jobname'])) ? ' - <span style="color: #1d1ab2;"><b>' . __('Job type') . ': </b></span>' . $eachtask['jobname'] : '';
+                    $jobnote = (!empty($eachtask['jobnote'])) ? ' - <span style="color: #1d1ab2;"><b>' . __('Job note') . ': </b></span>' . $eachtask['jobnote'] : '';
+                    $donenote = (!empty($eachtask['donenote'])) ? ' - <span style="color: #1d1ab2;"><b>' . __('Finish note') . ': </b></span>' . $eachtask['donenote'] : '';
+                    $donedate = (!empty($eachtask['enddate'])) ? ' - <span style="color: #1d1ab2;"><b>' . __('Finish date') . ': </b></span>' . $eachtask['enddate'] : '';
+
+                    $doneemploee = (!empty($allemployee[$eachtask['employeedone']])) ? '<b>' . $allemployee[$eachtask['employeedone']] . '</b>'  : '';
+                } else {
+                    $jobtype = (!empty($eachtask['jobname'])) ? ' - ' . __('Job type') . ': ' . $eachtask['jobname'] : '';
+                    $jobnote = (!empty($eachtask['jobnote'])) ? ' - ' . __('Job note') . ': ' . $eachtask['jobnote'] : '';
+                    $donenote = (!empty($eachtask['donenote'])) ? ' - ' . __('Finish note') . ': ' . $eachtask['donenote'] : '';
+                    $donedate = (!empty($eachtask['enddate'])) ? ' - ' . __('Finish date') . ': ' . $eachtask['enddate'] : '';
+                }
+                $extendInfo = $jobtype . $jobnote . $donenote . $donedate;
+            } else {
+                $extendInfo = '';
+            }
+
             $result .= "
                       {
-                        title: '" . $eachtask['address'] . " - " . @$allemployee[$eachtask['employeedone']] . $adcText . "',
+                        title: '" . $eachtask['address'] . " - " . $doneemploee . $adcText . mysql_real_escape_string($extendInfo) . "',
                         start: new Date(" . $startdate . "),
                         end: new Date(" . $enddate . "),
                         url: '?module=taskman&edittask=" . $eachtask['id'] . "'

--- a/config/alter.ini
+++ b/config/alter.ini
@@ -897,3 +897,7 @@ IBAN_ENABLED=0
 ;ASTERISK_CALLRECS_CEL_TAB_NAME=""
 ;file extension of your asterisk call recordings. leave blank to consider all files in place
 ;ASTERISK_CALLRECS_FORMAT=""
+;show some extended info for done tasks
+;TASKMAN_SHOW_DONE_EXTENDED=0
+;alternate styling of the extended info for done tasks
+;TASKMAN_DONE_EXTENDED_ALTERSTYLING=0

--- a/modules/general/taskman/index.php
+++ b/modules/general/taskman/index.php
@@ -138,10 +138,17 @@ if (cfr('TASKMAN')) {
                         // Task logs
                         show_window(__('View log'), ts_renderLogsListAjax());
                     } else {
+                        $showExtendedDone = $ubillingConfig->getAlterParam('TASKMAN_SHOW_DONE_EXTENDED');
+                        $extendedDoneAlterStyling = $ubillingConfig->getAlterParam('TASKMAN_DONE_EXTENDED_ALTERSTYLING');
+                        $extendedDoneAlterStylingBool = ($extendedDoneAlterStyling > 0);
+                        $extendedDoneAlterListOnly = ($extendedDoneAlterStylingBool and $extendedDoneAlterStyling == 2);
+
                         //custom jobtypes color styling
                         $customJobColorStyle = ts_GetAllJobtypesColorStyles();
                         //show full calendar view
-                        show_window('', $customJobColorStyle . wf_FullCalendar($showtasks, $fullCalendarOpts));
+                        show_window('', $customJobColorStyle . wf_FullCalendar($showtasks, $fullCalendarOpts,
+                                                                               $extendedDoneAlterStylingBool,
+                                                                               $extendedDoneAlterListOnly));
                     }
                 } else {
                     show_window(__('Show late'), ts_ShowLate());


### PR DESCRIPTION
New alter.ini non-mandatory options:
;show some extended info for done tasks
;TASKMAN_SHOW_DONE_EXTENDED=0
;alternate styling of the extended info for done tasks
;TASKMAN_DONE_EXTENDED_ALTERSTYLING=0

Module Taskman: from now on can display extended info for done task and to separate the displayin for different views.
api.astral: from now on you can use HTML in events titles for a fullcalendar widget. This ability is controlled by 2 additional parameters.