### PR TITLE
online_vsratye_upgrades

### DIFF
--- a/api/libs/api.mobilesext.php
+++ b/api/libs/api.mobilesext.php
@@ -119,6 +119,7 @@ class MobilesExt {
             $newId = simple_get_lastid('mobileext');
             $result = $newId;
             log_register('MOBILEEXT CREATE (' . $login . ') MOBILE `' . $mobile . '` [' . $newId . ']');
+            zb_GetAllAllPhonesCacheClean();
         }
         return ($result);
     }
@@ -137,6 +138,7 @@ class MobilesExt {
             $query = "DELETE from `mobileext` WHERE `id`='" . $mobileId . "';";
             nr_query($query);
             log_register('MOBILEEXT DELETE (' . $mobileData['login'] . ') MOBILE `' . $mobileData['mobile'] . '` [' . $mobileId . ']');
+            zb_GetAllAllPhonesCacheClean();
         }
     }
 
@@ -157,6 +159,7 @@ class MobilesExt {
             if ((!empty($mobile)) AND ( $mobileData['mobile'] != $mobile)) {
                 simple_update_field('mobileext', 'mobile', $mobile, $where);
                 log_register('MOBILEEXT CHANGE (' . $mobileData['login'] . ') MOBILE ON `' . $mobile . '` [' . $mobileId . ']');
+                zb_GetAllAllPhonesCacheClean();
             }
 
             if ($mobileData['notes'] != $notes) {

--- a/config/alter.ini
+++ b/config/alter.ini
@@ -901,3 +901,8 @@ IBAN_ENABLED=0
 ;TASKMAN_SHOW_DONE_EXTENDED=0
 ;alternate styling of the extended info for done tasks
 ;TASKMAN_DONE_EXTENDED_ALTERSTYLING=0
+;show last fee charge column in online tab. extremely vsratyi shit, kurwa. use at your own risk and with HP_MODE=1 ONLY.
+;"stgfeecharge2mysql" RemoteAPI call needed for this shit to work properly
+;ONLINE_SHOW_LAST_FEECHARGE=0
+;show all phone numbers assigned to user in online tab
+;ONLINE_SHOW_PHONES=0

--- a/modules/general/online/index.php
+++ b/modules/general/online/index.php
@@ -27,6 +27,11 @@ if ($system->checkForRight('ONLINE')) {
             $ShowContractField = true;
         }
 
+        $showUserPhones = false;
+        if (isset($alter_conf['ONLINE_SHOW_PHONES']) && $alter_conf['ONLINE_SHOW_PHONES']) {
+            $showUserPhones = true;
+        }
+
         $columnDefs = '';
         $showONUSignals = false;
         $showWIFISignals = false;
@@ -34,7 +39,7 @@ if ($system->checkForRight('ONLINE')) {
         if (isset($alter_conf['PON_ENABLED']) && $alter_conf['PON_ENABLED'] &&
             isset($alter_conf['ONLINE_SHOW_ONU_SIGNALS']) && $alter_conf['ONLINE_SHOW_ONU_SIGNALS']) {
             $showONUSignals = true;
-            $colNum1 = ($ShowContractField) ? '4' : '3';
+            $colNum1 = (($ShowContractField and $showUserPhones) ? '5' : (($ShowContractField xor $showUserPhones) ? '4' : '3'));
 
             $columnDefs.= '{"targets": ' . $colNum1 . ',
                                 "render": function ( data, type, row ) {                                          
@@ -56,7 +61,11 @@ if ($system->checkForRight('ONLINE')) {
         if (isset($alter_conf['MTSIGMON_ENABLED']) && $alter_conf['MTSIGMON_ENABLED'] &&
             isset($alter_conf['ONLINE_SHOW_WIFI_SIGNALS']) && $alter_conf['ONLINE_SHOW_WIFI_SIGNALS']) {
             $showWIFISignals = true;
-            $colNum2 = (($ShowContractField and $showONUSignals) ? '5' : ((!$ShowContractField and !$showONUSignals) ? '3' : '4'));
+
+            // fuckin' XOR magic goes below this line. don't touch it(especially the parentheses) or you'll be cursed with hours of debugging
+            $colNum2 = (($ShowContractField and $showUserPhones and $showONUSignals) ? '6' :
+                        ((($ShowContractField and $showUserPhones) xor ($showUserPhones and $showONUSignals) xor ($ShowContractField and $showONUSignals)) ? '5' :
+                        (($ShowContractField xor $showUserPhones xor $showONUSignals) ? '4' : '3')));
 
             $columnDefs.= (empty($columnDefs) ? '' : ', ');
             $columnDefs.= '{"targets": ' . $colNum2 . ',
@@ -85,6 +94,11 @@ if ($system->checkForRight('ONLINE')) {
                             }, ';
         }
 
+        $showLastFeeCharge = false;
+        if (isset($alter_conf['ONLINE_SHOW_LAST_FEECHARGE']) && $alter_conf['ONLINE_SHOW_LAST_FEECHARGE']) {
+            $showLastFeeCharge = true;
+        }
+
         $columnDefs = '"columnDefs": [ ' . $columnDefs . '], ';
 
         //alternate center styling
@@ -99,8 +113,9 @@ if ($system->checkForRight('ONLINE')) {
             $columnFilters = '
              null, ' .
                     ( ($hp_mode == 1 && $ShowContractField) ? 'null,' : '' ) .
-                    ' null,
-                { "sType": "ip-address" }, ' .
+                    ' null, ' .
+                ( ($hp_mode == 1 && $showUserPhones) ? 'null,' : '' ) .
+                ' { "sType": "ip-address" }, ' .
                 ( ($hp_mode == 1 && $showONUSignals) ? 'null, ' : '' ) .
                 ( ($hp_mode == 1 && $showWIFISignals) ? 'null, ' : '' ) .
                 ' null,
@@ -108,22 +123,23 @@ if ($system->checkForRight('ONLINE')) {
                 null,
                 { "sType": "file-size" },
                 null,
-                null
-            ';
+                null ' .
+                ( ($hp_mode == 1 && $showLastFeeCharge) ? ', null' : '' );
         } else {
             $columnFilters = '
              null, ' .
                     ( ($hp_mode == 1 && $ShowContractField) ? 'null,' : '' ) .
-                    ' null,
-                { "sType": "ip-address" }, ' .
+                    ' null, ' .
+                ( ($hp_mode == 1 && $showUserPhones) ? 'null,' : '' ) .
+                ' { "sType": "ip-address" }, ' .
                 ( ($hp_mode == 1 && $showONUSignals) ? 'null, ' : '' ) .
                 ( ($hp_mode == 1 && $showWIFISignals) ? 'null, ' : '' ) .
                 ' null,
                 null,
                 { "sType": "file-size" },
-                null,
-                null
-            ';
+                null,                
+                null ' .
+                ( ($hp_mode == 1 && $showLastFeeCharge) ? ', null' : '' );
         }
 
         $dtcode = '
@@ -269,6 +285,7 @@ if ($system->checkForRight('ONLINE')) {
         $result.= wf_TableCell(__('Full address'));
         $result.= ( ($hp_mode == 1 && $ShowContractField) ? wf_TableCell(__('Contract')) : '' );
         $result.= wf_TableCell(__('Real Name'));
+        $result.= ( ($hp_mode == 1 && $showUserPhones) ? wf_TableCell(__("Phones")) : '' );
         $result.= wf_TableCell(__('IP'));
         $result.= ( ($hp_mode == 1 && $showONUSignals) ? wf_TableCell(__("ONU Signal")) : '' );
         $result.= ( ($hp_mode == 1 && $showWIFISignals) ? wf_TableCell(__("Signal") . ' WiFi') : '' );
@@ -278,6 +295,7 @@ if ($system->checkForRight('ONLINE')) {
         $result.= wf_TableCell(__('Traffic'));
         $result.= wf_TableCell(__('Balance'));
         $result.= wf_TableCell(__('Credit'));
+        $result.= ( ($hp_mode == 1 && $showLastFeeCharge) ? wf_TableCell(__("Last fee charge")) : '' );
         $result.= wf_tag('tr', true);
         $result.= wf_tag('thead', true);
         $result.= wf_tag('table', true);
@@ -296,6 +314,7 @@ if ($system->checkForRight('ONLINE')) {
      */
     function zb_AjaxOnlineDataSourceSafe() {
         global $alter_conf;
+        $ubCache = new UbillingCache();
         $ishimuraOption = MultiGen::OPTION_ISHIMURA;
         $ishimuraTable = MultiGen::NAS_ISHIMURA;
         $additionalTraffic = array();
@@ -393,6 +412,41 @@ if ($system->checkForRight('ONLINE')) {
             $allWiFiSignals = $WiFiSigmon->getAllWiFiSignals();
         }
 
+        $allFees = array();
+        $showLastFeeCharge = false;
+        if (isset($alter_conf['ONLINE_SHOW_LAST_FEECHARGE']) && $alter_conf['ONLINE_SHOW_LAST_FEECHARGE']) {
+            $showLastFeeCharge = true;
+            $allFees = $ubCache->get('STG_FEE_CHARGE');
+        }
+
+        $showUserPhones = false;
+        $allUserPhones = array();
+        if (isset($alter_conf['ONLINE_SHOW_PHONES']) && $alter_conf['ONLINE_SHOW_PHONES']) {
+            $showUserPhones = true;
+            $allUserDataCached = zb_GetAllAllPhonesCache();
+
+            if (!empty($allUserDataCached)) {
+                foreach ($allUserDataCached as $eachLogin => $eachData) {
+                    $userPhones = (empty($eachData['phone'])) ? '' : str_ireplace(array('+', "-"), '', $eachData['phone']) . ' ';
+                    $userPhones.= (empty($eachData['mobile'])) ? '' : str_ireplace(array('+', "-"), '', $eachData['mobile']);
+
+                    if (!empty($eachData['mobiles'])) {
+                        $userPhones .= '<br />' ;
+
+                        foreach ($eachData['mobiles'] as $extmobile) {
+                            $userPhones .= (empty($extmobile)) ? '' : str_ireplace(array('+', "-"), '', $extmobile) . ' ';
+                        }
+                    }
+
+                    if (!empty($userPhones)) {
+                        $allUserPhones[$eachLogin] = $userPhones;
+                    }
+                }
+            }
+
+            unset($allUserDataCached);
+        }
+
         $query = "SELECT * FROM `users`";
         $query_fio = "SELECT * from `realname`";
         $allusers = simple_queryall($query);
@@ -479,6 +533,8 @@ if ($system->checkForRight('ONLINE')) {
 
                 $onuSignal = '';
                 $wifiSignal = '';
+                $feeCharge = '';
+                $userPhones = '';
 
                 if ($showONUSignals and isset($allONUSignals[$eachuser['login']])) {
                     $onuSignal = $allONUSignals[$eachuser['login']];
@@ -488,15 +544,28 @@ if ($system->checkForRight('ONLINE')) {
                     $wifiSignal = $allWiFiSignals[$eachuser['login']];
                 }
 
+                if ($showLastFeeCharge and isset($allFees[$eachuser['login']])) {
+                    $feeCharge = $allFees[$eachuser['login']]['max_date'] . '<br />' . ($allFees[$eachuser['login']]['balance_to'] - $allFees[$eachuser['login']]['balance_from']);
+                }
+
+                if ($showUserPhones and isset($allUserPhones[$eachuser['login']])) {
+                    $userPhones = $allUserPhones[$eachuser['login']];
+                }
+
                 if (!$alter_conf['DEAD_HIDE']) {
                     $jsonItem = array();
                     $jsonItem[] = '<a href=?module=traffstats&username=' . $eachuser['login'] . '><img src=skins/icon_stats.gif border=0 title=' . __('Stats') . '></a> <a href=?module=userprofile&username=' . $eachuser['login'] . '><img src=skins/icon_user.gif border=0 title=' . __('Profile') . '></a> ' . $fastcashlink . $addrDelimiter . $clearuseraddress;
 
                     if ($ShowContractField) {
-                        $jsonItem[] = @$allcontracts[$eachuser['login']] . ( ($ShowContractDate) ? wf_tag('br') . @$allcontractdates[$eachuser['login']] : '' );
+                        $jsonItem[] = @$allcontracts[$eachuser['login']] . (($ShowContractDate) ? wf_tag('br') . @$allcontractdates[$eachuser['login']] : '');
                     }
 
                     $jsonItem[] = @$fioz[$eachuser['login']] . (($showUserNotes and isset($allUserNotes[$eachuser['login']]['note'])) ? wf_delimiter(0) . '( ' . $allUserNotes[$eachuser['login']]['note'] . ' )' . $allUserNotes[$eachuser['login']]['adcomment'] : '');
+
+                    if ($showUserPhones) {
+                        $jsonItem[] = $userPhones;
+                    }
+
                     $jsonItem[] = $eachuser['IP'];
 
                     if ($showONUSignals) {
@@ -515,6 +584,11 @@ if ($system->checkForRight('ONLINE')) {
                     $jsonItem[] = zb_TraffToGb($tinet);
                     $jsonItem[] = "" . round($eachuser['Cash'], 2);
                     $jsonItem[] = "" . round($eachuser['Credit'], 2);
+
+                    if ($showLastFeeCharge) {
+                        $jsonItem[] = $feeCharge;
+                    }
+
                     $jsonAAData[] = $jsonItem;
                 } else {
                     if (!isset($deadUsers[$eachuser['login']])) {
@@ -526,6 +600,11 @@ if ($system->checkForRight('ONLINE')) {
                         }
 
                         $jsonItem[] = @$fioz[$eachuser['login']] . (($showUserNotes and isset($allUserNotes[$eachuser['login']]['note'])) ? wf_delimiter(0) . '( ' . $allUserNotes[$eachuser['login']]['note'] . ' )' . $allUserNotes[$eachuser['login']]['adcomment'] : '');
+
+                        if ($showUserPhones) {
+                            $jsonItem[] = $userPhones;
+                        }
+
                         $jsonItem[] = $eachuser['IP'];
 
                         if ($showONUSignals) {
@@ -544,6 +623,11 @@ if ($system->checkForRight('ONLINE')) {
                         $jsonItem[] = zb_TraffToGb($tinet);
                         $jsonItem[] = "" . round($eachuser['Cash'], 2);
                         $jsonItem[] = "" . round($eachuser['Credit'], 2);
+
+                        if ($showLastFeeCharge) {
+                            $jsonItem[] = $feeCharge;
+                        }
+
                         $jsonAAData[] = $jsonItem;
                     }
                 }


### PR DESCRIPTION
New alter.ini non-mandatory options:
;ONLINE_SHOW_LAST_FEECHARGE=0
;ONLINE_SHOW_PHONES=0

Module Online:
from now on can display subscriber's phones(all phones, including ext mobiles). Only with HP_MODE=1.
from now on has an extremely vsratuyu bullshitty ability to display "last fee charge". ONLY with HP_MODE=1.
Can awfully slow down the rendering of "Online table" and GUI in general.
to work correctly it demands SEPARATE(!) RemoteAPI call to fulfill it's cache with data from stargazer.log
don't ask me "For what?"
don't ask me "Why?"
just think twice, don't forgot
or your system will cry