### PR TITLE
pon_onu_mac_validate

### DIFF
--- a/api/libs/api.pon.php
+++ b/api/libs/api.pon.php
@@ -182,7 +182,7 @@ class PONizer {
      *
      * @var string
      */
-    protected $onuMACValidateRegex = '/(([0-9A-Fa-f]{2})|([0-9A-Fa-f]{4}))(?=([\.:-]))((?:\4(?2)){5}|(?:\4(?3)){2})$/';
+    protected $onuMACValidateRegex = '/^([[:xdigit:]]{2}[\s:.-]?){5}[[:xdigit:]]{2}$/';
 
 
     /**
@@ -3795,7 +3795,7 @@ class PONizer {
         global $ubillingConfig;
         $allOnuSignals = array();
         $signalCache = array();
-        $onuMACValidateRegex = '/(([0-9A-Fa-f]{2})|([0-9A-Fa-f]{4}))(?=([\.:-]))((?:\4(?2)){5}|(?:\4(?3)){2})$/';
+        $onuMACValidateRegex = '/^([[:xdigit:]]{2}[\s:.-]?){5}[[:xdigit:]]{2}$/';
         $validateONUMACEnabled = $ubillingConfig->getAlterParam('PON_ONU_MAC_VALIDATE');
         $availCacheData = rcms_scandir(self::SIGCACHE_PATH, '*_' . self::SIGCACHE_EXT);
 

--- a/api/libs/api.pon.php
+++ b/api/libs/api.pon.php
@@ -178,6 +178,28 @@ class PONizer {
     protected $ponizerUseTabUI = false;
 
     /**
+     * Placeholder for onu MAC validation regex
+     *
+     * @var string
+     */
+    protected $onuMACValidateRegex = '/(([0-9A-Fa-f]{2})|([0-9A-Fa-f]{4}))(?=([\.:-]))((?:\4(?2)){5}|(?:\4(?3)){2})$/';
+
+
+    /**
+     * Perform ONU MAC validation against $onuMACValidateRegex?
+     *
+     * @var bool
+     */
+    protected $validateONUMACEnabled = false;
+
+    /**
+     * Replace ONU's MAC if invalid with a random one?
+     *
+     * @var string
+     */
+    protected $replaceInvalidONUMACWithRandom = false;
+
+    /**
      * Placeholder for UbillingConfig object
      *
      * @var null
@@ -236,6 +258,8 @@ class PONizer {
         $this->onuUknownUserByMACSearchShowAlways = $this->ubConfig->getAlterParam('PON_UONU_USER_BY_MAC_SEARCH_SHOW_ALWAYS');
         $this->onuUknownUserByMACSearchTelepathy = $this->ubConfig->getAlterParam('PON_UONU_USER_BY_MAC_SEARCH_TELEPATHY');
         $this->ponizerUseTabUI = $this->ubConfig->getAlterParam('PON_UI_USE_TABS');
+        $this->validateONUMACEnabled = $this->ubConfig->getAlterParam('PON_ONU_MAC_VALIDATE');
+        $this->replaceInvalidONUMACWithRandom = $this->ubConfig->getAlterParam('PON_ONU_MAC_MAKE_RANDOM_IF_INVALID');
 
         //optional ONU MAC hiding
         if (@$this->altCfg['PON_ONU_HIDE']) {
@@ -3118,6 +3142,15 @@ class PONizer {
                 $raw = file_get_contents(self::SIGCACHE_PATH . $each);
                 $raw = unserialize($raw);
                 foreach ($raw as $mac => $signal) {
+                    if ($this->validateONUMACEnabled and !$this->validateONUMAC($mac)) {
+                        if ($this->replaceInvalidONUMACWithRandom) {
+                            $macRandom = 'FF:' . '00' . ':' . rand(10, 99) . ':' . rand(10, 99) . ':' . rand(10, 99) . ':' . '00';
+                            $this->signalCache[$macRandom] = $signal;
+                        }
+
+                        continue;
+                    }
+
                     $this->signalCache[$mac] = $signal;
                 }
             }
@@ -3136,6 +3169,15 @@ class PONizer {
                 $raw = file_get_contents(self::DISTCACHE_PATH . $each);
                 $raw = unserialize($raw);
                 foreach ($raw as $mac => $distance) {
+                    if ($this->validateONUMACEnabled and !$this->validateONUMAC($mac)) {
+                        if ($this->replaceInvalidONUMACWithRandom) {
+                            $macRandom = 'FF:' . '00' . ':' . rand(10, 99) . ':' . rand(10, 99) . ':' . rand(10, 99) . ':' . '00';
+                            $this->distanceCache[$macRandom] = $distance;
+                        }
+
+                        continue;
+                    }
+
                     $this->distanceCache[$mac] = $distance;
                 }
             }
@@ -3154,6 +3196,15 @@ class PONizer {
                 $raw = file_get_contents(self::DEREGCACHE_PATH . $each);
                 $raw = unserialize($raw);
                 foreach ($raw as $mac => $dereg) {
+                    if ($this->validateONUMACEnabled and !$this->validateONUMAC($mac)) {
+                        if ($this->replaceInvalidONUMACWithRandom) {
+                            $macRandom = 'FF:' . '00' . ':' . rand(10, 99) . ':' . rand(10, 99) . ':' . rand(10, 99) . ':' . '00';
+                            $this->lastDeregCache[$macRandom] = $dereg;
+                        }
+
+                        continue;
+                    }
+
                     $this->lastDeregCache[$mac] = $dereg;
                 }
             }
@@ -3172,6 +3223,15 @@ class PONizer {
                 $raw = file_get_contents(self::INTCACHE_PATH . $each);
                 $raw = unserialize($raw);
                 foreach ($raw as $mac => $interface) {
+                    if ($this->validateONUMACEnabled and !$this->validateONUMAC($mac)) {
+                        if ($this->replaceInvalidONUMACWithRandom) {
+                            $macRandom = 'FF:' . '00' . ':' . rand(10, 99) . ':' . rand(10, 99) . ':' . rand(10, 99) . ':' . '00';
+                            $this->interfaceCache[$macRandom] = $interface;
+                        }
+
+                        continue;
+                    }
+
                     $this->interfaceCache[$mac] = $interface;
                 }
             }
@@ -3190,6 +3250,15 @@ class PONizer {
                 $raw = file_get_contents(self::FDBCACHE_PATH . $each);
                 $raw = unserialize($raw);
                 foreach ($raw as $oidMac => $FDB) {
+                    if ($this->validateONUMACEnabled and !$this->validateONUMAC($oidMac)) {
+                        if ($this->replaceInvalidONUMACWithRandom) {
+                            $macRandom = 'FF:' . '00' . ':' . rand(10, 99) . ':' . rand(10, 99) . ':' . rand(10, 99) . ':' . '00';
+                            $this->FDBCache[$macRandom] = $FDB;
+                        }
+
+                        continue;
+                    }
+
                     $this->FDBCache[$oidMac] = $FDB;
                 }
             }
@@ -3211,6 +3280,15 @@ class PONizer {
                 $oltId = explode('_', $each);
                 $oltId = @vf($oltId[0], 3);
                 foreach ($raw as $index => $mac) {
+                    if ($this->validateONUMACEnabled and !$this->validateONUMAC($mac)) {
+                        if ($this->replaceInvalidONUMACWithRandom) {
+                            $macRandom = 'FF:' . '00' . ':' . rand(10, 99) . ':' . rand(10, 99) . ':' . rand(10, 99) . ':' . '00';
+                            $this->onuIndexCache[$macRandom] = $oltId;
+                        }
+
+                        continue;
+                    }
+
                     $this->onuIndexCache[$mac] = $oltId;
                 }
             }
@@ -3714,8 +3792,11 @@ class PONizer {
      * @return array
      */
     public static function getAllONUSignals() {
+        global $ubillingConfig;
         $allOnuSignals = array();
         $signalCache = array();
+        $onuMACValidateRegex = '/(([0-9A-Fa-f]{2})|([0-9A-Fa-f]{4}))(?=([\.:-]))((?:\4(?2)){5}|(?:\4(?3)){2})$/';
+        $validateONUMACEnabled = $ubillingConfig->getAlterParam('PON_ONU_MAC_VALIDATE');
         $availCacheData = rcms_scandir(self::SIGCACHE_PATH, '*_' . self::SIGCACHE_EXT);
 
         $query = "SELECT * from `pononu`";
@@ -3727,6 +3808,13 @@ class PONizer {
                 $raw = unserialize($raw);
 
                 foreach ($raw as $mac => $signal) {
+                    if ($validateONUMACEnabled) {
+                        $matches = array();
+                        preg_match($onuMACValidateRegex, $mac, $matches);
+
+                        if (empty($matches[0])) { continue; }
+                    }
+
                     $signalCache[$mac] = $signal;
                 }
             }
@@ -3739,6 +3827,13 @@ class PONizer {
         }
 
         return ($allOnuSignals);
+    }
+
+    public function validateONUMAC($onuMAC) {
+        $matches = array();
+        preg_match($this->onuMACValidateRegex, $onuMAC, $matches);
+
+        return (!empty($matches[0]));
     }
 
 }

--- a/api/vendor/sms_services_APIs/GradwellSms.php
+++ b/api/vendor/sms_services_APIs/GradwellSms.php
@@ -1,0 +1,81 @@
+<?php
+
+class GradwellSms extends SMSServiceApi {
+    public function __construct($smsServiceId, array $smsPack = array()) {
+        parent::__construct($smsServiceId, $smsPack);
+    }
+
+    public function pushMessages() {
+        global $ubillingConfig;
+        $apikey = $this->serviceApiKey;
+        $sender = $this->serviceAlphaName;
+        $smsHistoryEnabled = $ubillingConfig->getAlterParam('SMS_HISTORY_ON');
+        $smsAdvancedEnabled = $ubillingConfig->getAlterParam('SMS_SERVICES_ADVANCED_ENABLED');
+        $telepatia = new Telepathy(false);
+
+        if ($smsHistoryEnabled) {
+            $telepatia->flushPhoneTelepathyCache();
+            $telepatia->usePhones();
+        }
+
+        $allSmsQueue = $this->smsMessagePack;
+        if (!empty($allSmsQueue)) {
+            $smsPacketId = strtoupper(md5(uniqid(rand(), true)));
+            log_register('SENDDOG GRADWELLSMS sending SMS packet ' . $smsPacketId);
+
+            foreach ($allSmsQueue as $eachsms) {
+                $url = $this->serviceGatewayAddr
+                    . '?auth=' . $apikey
+                    . '&originator=' . $sender
+                    . '&destination=' . str_replace(array('+', '440'), array('', '44'), $eachsms['number'])
+                    . '&message=' . urlencode($eachsms['message']);
+
+                $ch = curl_init($url);
+                curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+                curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+                curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+                $result = curl_exec($ch);
+                curl_close($ch);
+
+                if (strpos($result, 'OK:') !== false) {
+                    if (strpos($result, 'id') !== false and $smsHistoryEnabled) {
+                        $idPos  = strpos($result, 'id');
+                        $messID = trim(substr($result, $idPos + 2));
+
+                        //$PhoneToSearch = $this->sendDog->cutInternationalsFromPhoneNum($eachsms['number']);
+                        $Login = $telepatia->getByPhoneFast($eachsms['number']);
+
+                        if ($smsAdvancedEnabled) {
+                            $query = "INSERT INTO `sms_history` (`smssrvid`, `login`, `phone`, `srvmsgself_id`, `srvmsgpack_id`, `date_send`, `send_status`, `msg_text`) 
+                                                  VALUES (" . $this->serviceId . ", '" . $Login . "', '" . $eachsms['number'] . "', '" . $messID . "', '" . $smsPacketId . "', '" . curdatetime() . "', '" . __('Message queued') . "', '" . $eachsms['message'] . "');";
+                        } else {
+                            $query = "INSERT INTO `sms_history` (`login`, `phone`, `srvmsgself_id`, `srvmsgpack_id`, `date_send`, `send_status`, `msg_text`) 
+                                                  VALUES ('" . $Login . "', '" . $eachsms['number'] . "', '" . $messID . "', '" . $smsPacketId . "', '" . curdatetime() . "', '" . __('Message queued') . "', '" . $eachsms['message'] . "');";
+                        }
+                        nr_query($query);
+                    } else {
+                        log_register('SENDDOG GRADWELLSMS message ID not found - can\'t write history:  ' . $result);
+                    }
+                } elseif (strpos($result, 'ERR:') !== false) {
+                    log_register('SENDDOG GRADWELLSMS delivery failed with error:  ' . $result);
+                } else {
+                    log_register('SENDDOG GRADWELLSMS unknown server answer:  ' . $result);
+                }
+
+                //remove old sent message
+                $this->instanceSendDog->getSmsQueueInstance()->deleteSms($eachsms['filename']);
+            }
+        }
+    }
+
+    public function getBalance() {
+        $this->showErrorFeatureIsNotSupported();
+    }
+    public function getSMSQueue() {
+        $this->showErrorFeatureIsNotSupported();
+    }
+
+    public  function checkMessagesStatuses() {
+        log_register('Checking statuses for [' . get_class($this) . '] SMS service is not implemented');
+    }
+}

--- a/config/alter.ini
+++ b/config/alter.ini
@@ -946,3 +946,9 @@ PONMAP_ENABLED=0
 ;ROS script example for simple queues rules manipulating can be found in
 ;/content/documents/mlg_ros_lease_queue_rebuild
 ;MULTIGEN_USE_ROS_TRAFFIC_GRAPHS=0
+;Check ONU MAC against regex before put it to cache
+;Currently supported: 2-digits and 4-digits(BDCOM-style) octets delimited with ':', '-' or '.'
+;PON_ONU_MAC_VALIDATE=0
+;If you want not to exclude ONUs with invalid MAC - uncomment this option
+;to put specially designed random MAC instead: FF:00:XX:XX:XX:00
+;PON_ONU_MAC_MAKE_RANDOM_IF_INVALID=1


### PR DESCRIPTION
API PON: added ability to validate ONU's MAC before putting it to caches for further use which is controlled by PON_ONU_MAC_VALIDATE alter.ini option. If MAC is invalid - ONU won't be added to the cache. But this behaviour can be overridden by PON_ONU_MAC_MAKE_RANDOM_IF_INVALID alter.ini option.

SendDog advanced: new API implementation for GradWell SMS.