### PR TITLE
ros_stg_drv_custom_api_port

### DIFF
--- a/docs/presets/MikroTik/system/executer/mikrotik.drv
+++ b/docs/presets/MikroTik/system/executer/mikrotik.drv
@@ -66,8 +66,10 @@
         private function connect() {
             for ($ATTEMPT = 1; $ATTEMPT <= $this->config['attempts']; $ATTEMPT++) {
                 $this->connected = FALSE;
-                $this->log->message(__CLASS__, 'Connection attempt #' . $ATTEMPT . ' to ' . $this->parameters['ip'] . ':' . $this->config['api_port'] . '...', "api");
-                if ( $this->socket = @fsockopen($this->parameters['ip'], $this->config['api_port'], $this->error_no, $this->error_str, $this->config['timeout']) ) {
+                $portAPI = (empty($this->options['apiport'])) ? $this->config['api_port'] : $this->options['apiport'];
+
+                $this->log->message(__CLASS__, 'Connection attempt #' . $ATTEMPT . ' to ' . $this->parameters['ip'] . ':' . $portAPI . '...', "debug");
+                if ( $this->socket = @fsockopen($this->parameters['ip'], $portAPI, $this->error_no, $this->error_str, $this->config['timeout']) ) {
                     socket_set_timeout($this->socket, $this->config['timeout']);
 
                     if ( isset($this->options['use_new_conn_mode']) && $this->options['use_new_conn_mode'] ) {

--- a/modules/remoteapi/mikrotikdnshaper.php
+++ b/modules/remoteapi/mikrotikdnshaper.php
@@ -30,8 +30,9 @@ if ($_GET['action'] == 'mikrotikdnshaper') {
                 $MTikNasOpts = base64_decode($eachlogin['options']);
                 $MTikNasOpts = unserialize($MTikNasOpts);
                 $UseNewConnType = ( isset($MTikNasOpts['use_new_conn_mode']) && $MTikNasOpts['use_new_conn_mode'] ) ? true : false;
+                $apiPort = ( !empty($MTikNasOpts['apiport']) ) ? $MTikNasOpts['apiport'] : 8728;
 
-                $RouterOSAPI->connect($eachlogin['nasip'], $MTikNasOpts['username'], $MTikNasOpts['password'], $UseNewConnType);
+                $RouterOSAPI->connect($eachlogin['nasip'], $MTikNasOpts['username'], $MTikNasOpts['password'], $UseNewConnType, $apiPort);
 
                 if ($RouterOSAPI->connected) {
                     if (isset($_GET['param']) && ($_GET['param'] == 'downshift')) {


### PR DESCRIPTION
From now on custom ROS API port is used not only by Mikrotik Ext conf, but by stargazer ROS API "driver" and Mikrotik dynamic shaper.