### PR TITLE
vservices_periods_payfind_additional_filters

### DIFF
--- a/api/libs/api.astral.php
+++ b/api/libs/api.astral.php
@@ -761,6 +761,17 @@ function wf_getBoolFromVar($Variable, $CheckAsTrueFalseStr = false) {
 }
 
 /**
+ * Returns true if $value is empty() or null but not equals to 0 or '0'
+ *
+ * @param string $value
+ *
+ * @return bool
+ */
+function wf_emptyNonZero($value = '') {
+    return ( (empty($value) and $value !== 0 and $value !== '0') ? true : false );
+}
+
+/**
  * Construct HTML table row element
  * 
  * @param string $cells table row cells

--- a/api/libs/api.banksta2.php
+++ b/api/libs/api.banksta2.php
@@ -629,16 +629,18 @@ class Banksta2 {
      * Adds new fields mapping preset to DB
      *
      * @param $fmpName
-     * @param int $fmpColRealName
-     * @param int $fmpColAddr
-     * @param int $fmpColPaySum
-     * @param int $fmpColPayPurpose
-     * @param int $fmpColPayDate
-     * @param int $fmpColPayTime
-     * @param int $fmpColContract
+     * @param string $fmpColRealName
+     * @param string $fmpColAddr
+     * @param string $fmpColPaySum
+     * @param string $fmpColPayPurpose
+     * @param string $fmpColPayDate
+     * @param string $fmpColPayTime
+     * @param string $fmpColContract
      * @param int $fmpGuessContract
      * @param string $fmpContractDelimStart
      * @param string $fmpContractDelimEnd
+     * @param int $fmpContractMinLen
+     * @param int $fmpContractMaxLen
      * @param string $fmpSrvType
      * @param string $fmpInetStartDelim
      * @param string $fmpInetEndDelim
@@ -646,9 +648,20 @@ class Banksta2 {
      * @param string $fmpUKVDelimStart
      * @param string $fmpUKVDelimEnd
      * @param string $fmpUKVKeywords
+     * @param int $fmpSkipRow
+     * @param string $fmpColSkipRow
+     * @param string $fmpSkipRowKeywords
+     * @param int $fmpReplaceStrs
+     * @param string $fmpColReplaceStrs
+     * @param string $fmpStrsToReplace
+     * @param string $fmpStrsToReplaceWith
+     * @param string $fmpReplacementsCount
+     * @param int $fmpRemoveStrs
+     * @param string $fmpColRemoveStrs
+     * @param string $fmpStrsToRemove
      */
-    public function addFieldsMappingPreset($fmpName, $fmpColRealName = 0, $fmpColAddr = 0, $fmpColPaySum = 0, $fmpColPayPurpose = 0,
-                                           $fmpColPayDate = 0, $fmpColPayTime = 0, $fmpColContract = 0, $fmpGuessContract = 0,
+    public function addFieldsMappingPreset($fmpName, $fmpColRealName = 'NONE', $fmpColAddr = 'NONE', $fmpColPaySum = 'NONE', $fmpColPayPurpose = 'NONE',
+                                           $fmpColPayDate = 'NONE', $fmpColPayTime = 'NONE', $fmpColContract = 'NONE', $fmpGuessContract = 0,
                                            $fmpContractDelimStart = '', $fmpContractDelimEnd = '', $fmpContractMinLen = 0, $fmpContractMaxLen = 0,
                                            $fmpSrvType = '', $fmpInetStartDelim = '', $fmpInetEndDelim = '', $fmpInetKeywords = '',
                                            $fmpUKVDelimStart = '', $fmpUKVDelimEnd = '', $fmpUKVKeywords = '',
@@ -656,6 +669,15 @@ class Banksta2 {
                                            $fmpReplaceStrs = 0, $fmpColReplaceStrs = '', $fmpStrsToReplace = '', $fmpStrsToReplaceWith = '', $fmpReplacementsCount = '',
                                            $fmpRemoveStrs = 0, $fmpColRemoveStrs = '', $fmpStrsToRemove = ''
                                           ) {
+
+        $fmpColRealName     = (wf_emptyNonZero($fmpColRealName) ? 'NONE' : $fmpColRealName);
+        $fmpColAddr         = (wf_emptyNonZero($fmpColAddr) ? 'NONE' : $fmpColAddr);
+        $fmpColPaySum       = (wf_emptyNonZero($fmpColPaySum) ? 'NONE' : $fmpColPaySum);
+        $fmpColPayPurpose   = (wf_emptyNonZero($fmpColPayPurpose) ? 'NONE' : $fmpColPayPurpose);
+        $fmpColPayDate      = (wf_emptyNonZero($fmpColPayDate) ? 'NONE' : $fmpColPayDate);
+        $fmpColPayTime      = (wf_emptyNonZero($fmpColPayTime) ? 'NONE' : $fmpColPayTime);
+        $fmpColContract     = (wf_emptyNonZero($fmpColContract) ? 'NONE' : $fmpColContract);
+
         $tQuery = "INSERT INTO `" . self::BANKSTA2_PRESETS_TABLE .
                   "` (`presetname`, `col_realname`, `col_address`, `col_paysum`, `col_paypurpose`, `col_paydate`, 
                             `col_paytime`, `col_contract`, `guess_contract`, `contract_delim_start`, `contract_delim_end`, 
@@ -677,9 +699,44 @@ class Banksta2 {
         log_register('CREATE banksta2 fields mapping preset [' . $fmpName . ']');
     }
 
-
-    public function editFieldsMappingPreset($fmpID, $fmpName, $fmpColRealName = 0, $fmpColAddr = 0, $fmpColPaySum = 0, $fmpColPayPurpose = 0,
-                                            $fmpColPayDate = 0, $fmpColPayTime = 0, $fmpColContract = 0, $fmpGuessContract = 0,
+    /**
+     * Edits existing fields mapping preset
+     *
+     * @param $fmpID
+     * @param $fmpName
+     * @param string $fmpColRealName
+     * @param string $fmpColAddr
+     * @param string $fmpColPaySum
+     * @param string $fmpColPayPurpose
+     * @param string $fmpColPayDate
+     * @param string $fmpColPayTime
+     * @param string $fmpColContract
+     * @param int $fmpGuessContract
+     * @param string $fmpContractDelimStart
+     * @param string $fmpContractDelimEnd
+     * @param int $fmpContractMinLen
+     * @param int $fmpContractMaxLen
+     * @param string $fmpSrvType
+     * @param string $fmpInetStartDelim
+     * @param string $fmpInetEndDelim
+     * @param string $fmpInetKeywords
+     * @param string $fmpUKVDelimStart
+     * @param string $fmpUKVDelimEnd
+     * @param string $fmpUKVKeywords
+     * @param int $fmpSkipRow
+     * @param string $fmpColSkipRow
+     * @param string $fmpSkipRowKeywords
+     * @param int $fmpReplaceStrs
+     * @param string $fmpColReplaceStrs
+     * @param string $fmpStrsToReplace
+     * @param string $fmpStrsToReplaceWith
+     * @param string $fmpReplacementsCount
+     * @param int $fmpRemoveStrs
+     * @param string $fmpColRemoveStrs
+     * @param string $fmpStrsToRemove
+     */
+    public function editFieldsMappingPreset($fmpID, $fmpName, $fmpColRealName = 'NONE', $fmpColAddr = 'NONE', $fmpColPaySum = 'NONE', $fmpColPayPurpose = 'NONE',
+                                            $fmpColPayDate = 'NONE', $fmpColPayTime = 'NONE', $fmpColContract = 'NONE', $fmpGuessContract = 0,
                                             $fmpContractDelimStart = '', $fmpContractDelimEnd = '', $fmpContractMinLen = 0, $fmpContractMaxLen = 0,
                                             $fmpSrvType = '', $fmpInetStartDelim = '', $fmpInetEndDelim = '', $fmpInetKeywords = '',
                                             $fmpUKVDelimStart = '', $fmpUKVDelimEnd = '', $fmpUKVKeywords = '',
@@ -687,6 +744,15 @@ class Banksta2 {
                                             $fmpReplaceStrs = 0, $fmpColReplaceStrs = '', $fmpStrsToReplace = '', $fmpStrsToReplaceWith = '', $fmpReplacementsCount = '',
                                             $fmpRemoveStrs = 0, $fmpColRemoveStrs = '', $fmpStrsToRemove = ''
                                            ) {
+
+        $fmpColRealName     = (wf_emptyNonZero($fmpColRealName) ? 'NONE' : $fmpColRealName);
+        $fmpColAddr         = (wf_emptyNonZero($fmpColAddr) ? 'NONE' : $fmpColAddr);
+        $fmpColPaySum       = (wf_emptyNonZero($fmpColPaySum) ? 'NONE' : $fmpColPaySum);
+        $fmpColPayPurpose   = (wf_emptyNonZero($fmpColPayPurpose) ? 'NONE' : $fmpColPayPurpose);
+        $fmpColPayDate      = (wf_emptyNonZero($fmpColPayDate) ? 'NONE' : $fmpColPayDate);
+        $fmpColPayTime      = (wf_emptyNonZero($fmpColPayTime) ? 'NONE' : $fmpColPayTime);
+        $fmpColContract     = (wf_emptyNonZero($fmpColContract) ? 'NONE' : $fmpColContract);
+
         $tQuery = "UPDATE `" . self::BANKSTA2_PRESETS_TABLE . "` SET 
                             `presetname`            = '" . $fmpName . "', 
                             `col_realname`          = '" . $fmpColRealName . "',  
@@ -2215,9 +2281,12 @@ class Banksta2 {
                 }
 
                 $linkId1 = wf_InputId();
+                $linkId2 = wf_InputId();
                 $actions = wf_JSAlert(  '#', web_delete_icon(), 'Removing this may lead to irreparable results', 'deleteFMP(' . $eachRec['id'] . ', \'' . self::URL_ME . '\', \'delFMP\', \'' . wf_InputId() . '\')') . wf_nbsp();
                 $actions.= wf_Link('#', web_edit_icon(), false, '', 'id="' . $linkId1 . '"') . wf_nbsp();
+                $actions.= wf_Link('#', web_clone_icon(), false, '', 'id="' . $linkId2 . '"') . wf_nbsp();
                 $actions.= wf_JSAjaxModalOpener(self::URL_ME, array('fmpedit' => 'true', 'fmpid' => $fmpID), $linkId1, true, 'POST');
+                $actions.= wf_JSAjaxModalOpener(self::URL_ME, array('fmpclone' => 'true', 'fmpid' => $fmpID), $linkId2, true, 'POST');
 
                 $data[] = $actions;
 
@@ -2347,19 +2416,19 @@ class Banksta2 {
 
         $inputs = wf_TextInput('fmpname', __('Preset name'), '', true, '', '', '__FMPEmptyCheck');
 
-        $inputscells = wf_TableCell(wf_TextInput('fmpcolrealname', __('Real name column number'), '0', false, '4'));
-        $inputscells.= wf_TableCell(wf_TextInput('fmpcoladdr', __('Address column number'), '0', false, '4'));
-        $inputscells.= wf_TableCell(wf_TextInput('fmpcolpaysum', __('Payment sum column number'), '0', false, '4'));
+        $inputscells = wf_TableCell(wf_TextInput('fmpcolrealname', __('Real name column number'), 'NONE', false, '4'));
+        $inputscells.= wf_TableCell(wf_TextInput('fmpcoladdr', __('Address column number'), 'NONE', false, '4'));
+        $inputscells.= wf_TableCell(wf_TextInput('fmpcolpaysum', __('Payment sum column number'), 'NONE', false, '4'));
         $inputsrows = wf_TableRow($inputscells);
 
-        $inputscells = wf_TableCell(wf_TextInput('fmpcolpaypurpose', __('Payment purpose column number'), '0', false, '4'));
-        $inputscells.= wf_TableCell(wf_TextInput('fmpcolpaydate', __('Payment date column number'), '0', false, '4'));
-        $inputscells.= wf_TableCell(wf_TextInput('fmpcolpaytime', __('Payment time column number'), '0', true, '4'));
+        $inputscells = wf_TableCell(wf_TextInput('fmpcolpaypurpose', __('Payment purpose column number'), 'NONE', false, '4'));
+        $inputscells.= wf_TableCell(wf_TextInput('fmpcolpaydate', __('Payment date column number'), 'NONE', false, '4'));
+        $inputscells.= wf_TableCell(wf_TextInput('fmpcolpaytime', __('Payment time column number'), 'NONE', true, '4'));
         $inputsrows.= wf_TableRow($inputscells);
         $inputs.= wf_TableBody($inputsrows, '', '0', '', 'cellspacing="4px" style="margin-top: 8px;"');
 
         $inputs.= wf_tag('hr', false, '', 'style="margin-bottom: 11px;"');
-        $inputs.= wf_TextInput('fmpcolcontract', __('User contract column number') . ' (' . __('Payment ID') . ')', '0', true, '4');
+        $inputs.= wf_TextInput('fmpcolcontract', __('User contract column number') . ' (' . __('Payment ID') . ')', 'NONE', true, '4');
         $inputs.= wf_CheckInput('fmptryguesscontract', __('Try to get contract from payment purpose field'), true, false, 'BankstaTryGuessContract');
         $inputs.= wf_tag('h4', false, '', 'style="font-weight: 400; width: 800px; padding: 2px 0 8px 28px; color: #666; margin-block-end: 0; margin-block-start: 0;"');
         $inputs.= __('ONLY, if mapped contract field for some row will be empty or if contract field will be not specified');
@@ -2383,7 +2452,7 @@ class Banksta2 {
         $inputs.= wf_tag('hr', false, '', 'style="margin-bottom: 11px;"');
         $inputs.= wf_CheckInput('fmpskiprow', __('Skip row processing if specified fields contain keywords below'), true, false, 'BankstaSkipRow');
         $inputs.= wf_TextInput('fmpcolskiprow', __('Fields to check row skipping') . '(' . __('multiple fields must be separated with comas') . ')', '', true, '', '', '', 'BankstaSkipRowKeyWordsCol');
-        $inputs.= wf_TextInput('fmpskiprowkeywords', __('Row skipping determination keywords  ') . ', ' . __('separated with') . ' BANKSTA2_REGEX_KEYWORDS_DELIM', '', true, '40', '', '', 'BankstaSkipRowKeyWords');
+        $inputs.= wf_TextInput('fmpskiprowkeywords', __('Row skipping determination keywords') . ', ' . __('separated with') . ' BANKSTA2_REGEX_KEYWORDS_DELIM', '', true, '40', '', '', 'BankstaSkipRowKeyWords');
         $inputs.= wf_delimiter(0);
         $inputs.= wf_CheckInput('fmpreplacestrs', __('Replace characters specified below in specified fields'), true, false, 'BankstaReplaceStrs');
         $inputs.= wf_TextInput('fmpcolsreplacestrs', __('Fields to perform replacing') . '(' . __('multiple fields must be separated with comas') . ')', '', true, '', '', '', 'BankstaReplaceStrsCols');
@@ -2412,31 +2481,38 @@ class Banksta2 {
      *
      * @return string
      */
-    public function renderFMPEditForm($fmpID, $modalWindowId) {
-        $formId = 'Form_' . wf_InputId();
-        $closeFormChkId = 'CloseFrmChkID_' . wf_InputId();
+    public function renderFMPEditForm($fmpID, $modalWindowId, $clone = false) {
+        $formId             = 'Form_' . wf_InputId();
+        $closeFormChkId     = 'CloseFrmChkID_' . wf_InputId();
 
-        $fmpData = $this->fieldsMappingPresets[$fmpID];
-        $contractGuessing = (empty($fmpData['guess_contract'])) ? false : true;
-        $rowSkipping = (empty($fmpData['skip_row'])) ? false : true;
-        $strReplacing = (empty($fmpData['replace_strs'])) ? false : true;
-        $strRemoving = (empty($fmpData['remove_strs'])) ? false : true;
+        $fmpData            = $this->fieldsMappingPresets[$fmpID];
+        $colRealName        = (wf_emptyNonZero($fmpData['col_realname']) ? 'NONE' : $fmpData['col_realname']);
+        $colAddress         = (wf_emptyNonZero($fmpData['col_address']) ? 'NONE' : $fmpData['col_address']);
+        $colPaysum          = (wf_emptyNonZero($fmpData['col_paysum']) ? 'NONE' : $fmpData['col_paysum']);
+        $colPayPurpose      = (wf_emptyNonZero($fmpData['col_paypurpose']) ? 'NONE' : $fmpData['col_paypurpose']);
+        $colPayDate         = (wf_emptyNonZero($fmpData['col_paydate']) ? 'NONE' : $fmpData['col_paydate']);
+        $colPayTime         = (wf_emptyNonZero($fmpData['col_paytime']) ? 'NONE' : $fmpData['col_paytime']);
+        $colContract        = (wf_emptyNonZero($fmpData['col_contract']) ? 'NONE' : $fmpData['col_contract']);
+        $contractGuessing   = (empty($fmpData['guess_contract'])) ? false : true;
+        $rowSkipping        = (empty($fmpData['skip_row'])) ? false : true;
+        $strReplacing       = (empty($fmpData['replace_strs'])) ? false : true;
+        $strRemoving        = (empty($fmpData['remove_strs'])) ? false : true;
 
         $inputs = wf_TextInput('fmpname', __('Preset name'), $fmpData['presetname'], true, '', '', '__FMPEmptyCheck');
 
-        $inputscells = wf_TableCell(wf_TextInput('fmpcolrealname', __('Real name column number'), $fmpData['col_realname'], false, '4'));
-        $inputscells.= wf_TableCell(wf_TextInput('fmpcoladdr', __('Address column number'), $fmpData['col_address'], false, '4'));
-        $inputscells.= wf_TableCell(wf_TextInput('fmpcolpaysum', __('Payment sum column number'), $fmpData['col_paysum'], false, '4'));
+        $inputscells = wf_TableCell(wf_TextInput('fmpcolrealname', __('Real name column number'), $colRealName, false, '4'));
+        $inputscells.= wf_TableCell(wf_TextInput('fmpcoladdr', __('Address column number'), $colAddress, false, '4'));
+        $inputscells.= wf_TableCell(wf_TextInput('fmpcolpaysum', __('Payment sum column number'), $colPaysum, false, '4'));
         $inputsrows = wf_TableRow($inputscells);
 
-        $inputscells = wf_TableCell(wf_TextInput('fmpcolpaypurpose', __('Payment purpose column number'), $fmpData['col_paypurpose'], false, '4'));
-        $inputscells.= wf_TableCell(wf_TextInput('fmpcolpaydate', __('Payment date column number'), $fmpData['col_paydate'], false, '4'));
-        $inputscells.= wf_TableCell(wf_TextInput('fmpcolpaytime', __('Payment time column number'), $fmpData['col_paytime'], true, '4'));
+        $inputscells = wf_TableCell(wf_TextInput('fmpcolpaypurpose', __('Payment purpose column number'), $colPayPurpose, false, '4'));
+        $inputscells.= wf_TableCell(wf_TextInput('fmpcolpaydate', __('Payment date column number'), $colPayDate, false, '4'));
+        $inputscells.= wf_TableCell(wf_TextInput('fmpcolpaytime', __('Payment time column number'), $colPayTime, true, '4'));
         $inputsrows.= wf_TableRow($inputscells);
         $inputs.= wf_TableBody($inputsrows, '', '0', '', 'cellspacing="4px" style="margin-top: 8px;"');
 
         $inputs.= wf_tag('hr', false, '', 'style="margin-bottom: 11px;"');
-        $inputs.= wf_TextInput('fmpcolcontract', __('User contract column number') . ' (' . __('Payment ID') . ')', $fmpData['col_contract'], true, '4');
+        $inputs.= wf_TextInput('fmpcolcontract', __('User contract column number') . ' (' . __('Payment ID') . ')', $colContract, true, '4');
         $inputs.= wf_CheckInput('fmptryguesscontract', __('Try to get contract from payment purpose field'), true, $contractGuessing, 'BankstaTryGuessContract');
         $inputs.= wf_tag('h4', false, '', 'style="font-weight: 400; width: 800px; padding: 2px 0 8px 28px; color: #666; margin-block-end: 0; margin-block-start: 0;"');
         $inputs.= __('ONLY, if mapped contract field for some row will be empty or if contract field will be not specified');
@@ -2460,7 +2536,7 @@ class Banksta2 {
         $inputs.= wf_tag('hr', false, '', 'style="margin-bottom: 11px;"');
         $inputs.= wf_CheckInput('fmpskiprow', __('Skip row processing if specified fields contain keywords below'), true, $rowSkipping, 'BankstaSkipRow');
         $inputs.= wf_TextInput('fmpcolskiprow', __('Fields to check row skipping') . '(' . __('multiple fields must be separated with comas') . ')', $fmpData['col_skiprow'], true, '', '', '', 'BankstaSkipRowKeyWordsCol');
-        $inputs.= wf_TextInput('fmpskiprowkeywords', __('Row skipping determination keywords  ') . ', ' . __('separated with') . ' BANKSTA2_REGEX_KEYWORDS_DELIM', $fmpData['skip_row_keywords'], true, '40', '', '', 'BankstaSkipRowKeyWords');
+        $inputs.= wf_TextInput('fmpskiprowkeywords', __('Row skipping determination keywords') . ', ' . __('separated with') . ' BANKSTA2_REGEX_KEYWORDS_DELIM', $fmpData['skip_row_keywords'], true, '40', '', '', 'BankstaSkipRowKeyWords');
         $inputs.= wf_delimiter(0);
         $inputs.= wf_CheckInput('fmpreplacestrs', __('Replace characters specified below in specified fields'), true, $strReplacing, 'BankstaReplaceStrs');
         $inputs.= wf_TextInput('fmpcolsreplacestrs', __('Fields to perform replacing') . '(' . __('multiple fields must be separated with comas') . ')', $fmpData['col_replace_strs'], true, '', '', '', 'BankstaReplaceStrsCols');
@@ -2476,10 +2552,10 @@ class Banksta2 {
         $inputs.= wf_CheckInput('formclose', __('Close form after operation'), false, true, $closeFormChkId, '__CloseFrmOnSubmitChk');
 
         $inputs.= wf_HiddenInput('', $modalWindowId, '', '__FMPFormModalWindowId');
-        $inputs.= wf_HiddenInput('fmpedit', 'true');
+        $inputs.= ($clone) ? wf_HiddenInput('fmpclone', 'true') : wf_HiddenInput('fmpedit', 'true');
         $inputs.= wf_HiddenInput('fmpid', $fmpID);
         $inputs.= wf_delimiter();
-        $inputs.= wf_Submit(__('Edit'));
+        $inputs.= ($clone) ? wf_Submit(__('Clone')) : wf_Submit(__('Edit'));
         $form = wf_Form(self::URL_ME, 'POST', $inputs, 'glamour __FMPForm', '', $formId);
 
         return ($form);

--- a/api/libs/api.fundsflow.php
+++ b/api/libs/api.fundsflow.php
@@ -156,7 +156,7 @@ class FundsFlow {
             foreach ($cleardata as $eachline) {
                 $eachfee = explode(' ', $eachline);
                 if (isset($eachfee[1])) {
-                    $counter = strtotime($eachfee[0] . ' ' . $eachfee[1]);
+                    $counter = strtotime($eachfee[0] . ' ' . $eachfee[1]) + count($result);
 
                     $feefrom = str_replace("'.", '', $eachfee[12]);
                     $feeto = str_replace("'.", '', $eachfee[14]);
@@ -194,7 +194,7 @@ class FundsFlow {
 
         if (!empty($allpayments)) {
             foreach ($allpayments as $io => $eachpayment) {
-                $counter = strtotime($eachpayment['date']);
+                $counter = strtotime($eachpayment['date']) + count($result);
 
                 if (ispos($eachpayment['note'], 'MOCK:')) {
                     $cashto = $eachpayment['balance'];
@@ -239,7 +239,7 @@ class FundsFlow {
 
         if (!empty($allpayments)) {
             foreach ($allpayments as $io => $eachpayment) {
-                $counter = strtotime($eachpayment['date']);
+                $counter = strtotime($eachpayment['date']) + count($result);
                 $cashto = $eachpayment['summ'] + $eachpayment['balance'];
                 $result[$counter]['login'] = $login;
                 $result[$counter]['date'] = $eachpayment['date'];

--- a/api/libs/api.fundsflow.php
+++ b/api/libs/api.fundsflow.php
@@ -156,7 +156,7 @@ class FundsFlow {
             foreach ($cleardata as $eachline) {
                 $eachfee = explode(' ', $eachline);
                 if (isset($eachfee[1])) {
-                    $counter = strtotime($eachfee[0] . ' ' . $eachfee[1]) + count($result);
+                    $counter = strtotime($eachfee[0] . ' ' . $eachfee[1]);
 
                     $feefrom = str_replace("'.", '', $eachfee[12]);
                     $feeto = str_replace("'.", '', $eachfee[14]);
@@ -194,7 +194,7 @@ class FundsFlow {
 
         if (!empty($allpayments)) {
             foreach ($allpayments as $io => $eachpayment) {
-                $counter = strtotime($eachpayment['date']) + count($result);
+                $counter = strtotime($eachpayment['date']);
 
                 if (ispos($eachpayment['note'], 'MOCK:')) {
                     $cashto = $eachpayment['balance'];
@@ -239,7 +239,7 @@ class FundsFlow {
 
         if (!empty($allpayments)) {
             foreach ($allpayments as $io => $eachpayment) {
-                $counter = strtotime($eachpayment['date']) + count($result);
+                $counter = strtotime($eachpayment['date']);
                 $cashto = $eachpayment['summ'] + $eachpayment['balance'];
                 $result[$counter]['login'] = $login;
                 $result[$counter]['date'] = $eachpayment['date'];

--- a/api/libs/api.usertags.php
+++ b/api/libs/api.usertags.php
@@ -9,11 +9,12 @@
  * 
  * @return array
  */
-function zb_UserGetAllTags() {
+function zb_UserGetAllTags($login = '') {
     $result = array();
     $tagTypes = stg_get_alltagnames();
+    $queryWhere = (empty($login)) ? '' : " WHERE `login` = '" . $login . "'";
     if (!empty($tagTypes)) {
-        $query = "SELECT * from `tags`";
+        $query = "SELECT * from `tags`" . $queryWhere;
         $all = simple_queryall($query);
         if (!empty($all)) {
             foreach ($all as $io => $each) {
@@ -280,7 +281,7 @@ function stg_del_user_tag($tagid) {
         $tagsDb->delete();
         log_register('TAGDEL (' . $tagLogin . ') TAGID [' . $tagType . ']');
     } else {
-        log_register('TAGDEL (' . $tagLogin . ') TAGID [' . $tagType . '] FAIL_NOT_EXISTS');
+        log_register('TAGDEL TAGID [' . $tagid . '] FAIL_NOT_EXISTS');
     }
 }
 
@@ -358,17 +359,52 @@ function zb_FlushAllUserTags($login) {
  * @param int $tagid
  * @param float $price
  * @param string $cashtype
- * @param int  $priority
+ * @param int $priority
+ * @param int $feechargealways
+ * @param int $feechargeperiod
  */
-function zb_VserviceCreate($tagid, $price, $cashtype, $priority, $feechargealways) {
+function zb_VserviceCreate($tagid, $price, $cashtype, $priority, $feechargealways = 0, $feechargeperiod = 0) {
     $tagid = vf($tagid, 3);
     $price = mysql_real_escape_string($price);
     $cashtype = vf($cashtype);
     $priority = vf($priority, 3);
-    $query = "INSERT INTO `vservices` (`id` , `tagid` , `price` , `cashtype` , `priority`, `fee_charge_always`)
-              VALUES (NULL , '" . $tagid . "', '" . $price . "', '" . $cashtype . "', '" . $priority . "', '" . $feechargealways . "');";
+    $feechargeperiod = vf($feechargeperiod, 3);
+
+    $query = "INSERT INTO `vservices` (`id` , `tagid` , `price` , `cashtype` , `priority`, `fee_charge_always`, charge_period_days)
+              VALUES (NULL , '" . $tagid . "', '" . $price . "', '" . $cashtype . "', '" . $priority . "', '" . $feechargealways . "', " . $feechargeperiod . ");";
     nr_query($query);
-    log_register("CREATE VSERVICE [" . $tagid . '] `' . $price . '` [' . $cashtype . '] `' . $priority . '` [' . $feechargealways . '] `');
+    log_register("CREATE VSERVICE [" . $tagid . '] `' . $price . '` [' . $cashtype . '] `' . $priority . '` [' . $feechargealways . '] `' . '` [' . $feechargeperiod . '] `');
+}
+
+/**
+ * Edits virtual service
+ *
+ * @param int $vserviceID
+ * @param int $tagid
+ * @param float $price
+ * @param string $cashtype
+ * @param int  $priority
+ * @param int $feechargealways
+ * @param int $feechargeperiod
+ */
+function zb_VserviceEdit($vserviceID, $tagid, $price, $cashtype, $priority, $feechargealways = 0, $feechargeperiod = 0) {
+    $tagid = vf($tagid, 3);
+    $price = mysql_real_escape_string($price);
+    $cashtype = vf($cashtype);
+    $priority = vf($priority, 3);
+    $feechargeperiod = vf($feechargeperiod, 3);
+
+    $query = "UPDATE `vservices` SET 
+                    `tagid` = " . $tagid . ",   
+                    `price` = " . $price . ", 
+                    `cashtype` = '" . $cashtype . "', 
+                    `priority` = " . $priority . ", 
+                    `fee_charge_always` = " . $feechargealways . ",
+                    `charge_period_days` = " . $feechargeperiod . "
+                WHERE `id` = " . $vserviceID;
+    nr_query($query);
+
+    log_register("CHANGE VSERVICE [" . $vserviceID . "] PRICE `" . $price . "`");
 }
 
 /**
@@ -440,7 +476,8 @@ function web_VserviceAddForm() {
     $inputs = stg_tagid_selector() . wf_tag('br');
     $inputs .= wf_Selector('newcashtype', $serviceFeeTypes, __('Cash type'), '', true);
     $inputs .= web_priority_selector() . wf_tag('br');
-    $inputs .= wf_TextInput('newfee', __('Fee'), '', true, '5');
+    $inputs .= wf_TextInput('newfee', __('Fee'), '', true, '5', 'finance');
+    $inputs .= wf_TextInput('newperiod', __('Charge period in days'), '', true, '5', 'digits');
     $inputs .= wf_CheckInput('feechargealways', __('Always charge fee, even if balance cash < 0'), true, false);
     $inputs .= wf_Submit(__('Create'));
     $form = wf_Form("", 'POST', $inputs, 'glamour');
@@ -473,13 +510,14 @@ function web_VserviceEditForm($vserviceid) {
             $priorities[$i] = $i;
         }
 
-        $FeeIsChargedAlways = ($serviceData['fee_charge_always'] == 1) ? true : false;
+        $feeIsChargedAlways = ($serviceData['fee_charge_always'] == 1) ? true : false;
 
         $inputs = wf_Selector('edittagid', $allTags, __('Tag'), $serviceData['tagid'], true);
         $inputs .= wf_Selector('editcashtype', $serviceFeeTypes, __('Cash type'), $serviceData['cashtype'], true);
         $inputs .= wf_Selector('editpriority', $priorities, __('Priority'), $serviceData['priority'], true);
-        $inputs .= wf_TextInput('editfee', __('Fee'), $serviceData['price'], true, '5');
-        $inputs .= wf_CheckInput('editfeechargealways', __('Always charge fee, even if balance cash < 0'), true, $FeeIsChargedAlways);
+        $inputs .= wf_TextInput('editfee', __('Fee'), $serviceData['price'], true, '5', 'finance');
+        $inputs .= wf_TextInput('editperiod', __('Charge period in days'), $serviceData['charge_period_days'], true, '5', 'digits');
+        $inputs .= wf_CheckInput('editfeechargealways', __('Always charge fee, even if balance cash < 0'), true, $feeIsChargedAlways);
         $inputs .= wf_Submit(__('Save'));
 
         $form = wf_Form("", 'POST', $inputs, 'glamour');
@@ -507,14 +545,16 @@ function web_VservicesShow() {
         'Fee',
         'Cash type',
         'Priority',
-        'Always charge fee'
+        'Always charge fee',
+        'Charge period in days'
     );
     $keys = array('id',
         'tagid',
         'price',
         'cashtype',
         'priority',
-        'fee_charge_always'
+        'fee_charge_always',
+        'charge_period_days'
     );
     show_window(__('Virtual services'), web_GridEditorVservices($titles, $keys, $allvservices, 'vservices', true, true));
     if (!empty($alltagtypes)) {
@@ -675,14 +715,16 @@ function web_VservicesSelector() {
  * 
  * @param bool $log_payment
  * @param bool $charge_frozen
- * 
+ * @param string $whereString
+ *
  * @return void
  */
-function zb_VservicesProcessAll($log_payment = true, $charge_frozen = true) {
+function zb_VservicesProcessAll($log_payment = true, $charge_frozen = true, $whereString = '') {
     global $ubillingConfig;
     $alterconf = $ubillingConfig->getAlter();
     $frozenUsers = array();
-    $query_services = "SELECT * from `vservices` ORDER by `priority` DESC";
+    $query_services = "SELECT * from `vservices` " . $whereString . " ORDER by `priority` DESC";
+
     $allUserData = zb_UserGetAllStargazerDataAssoc();
     $paymentTypeId = 1;
     //custom payment type ID optional option
@@ -693,6 +735,7 @@ function zb_VservicesProcessAll($log_payment = true, $charge_frozen = true) {
     }
 
     $allservices = simple_queryall($query_services);
+
     if (!empty($allservices)) {
         if (!$charge_frozen) {
             $frozen_query = "SELECT `login` from `users` WHERE `Passive`='1';";
@@ -773,6 +816,25 @@ function zb_VservicesGetAllPrices() {
 }
 
 /**
+ * Returns array of all available virtual services as tagid => array('price' => $price, 'period' => $period);
+ *
+ * @return array
+ */
+function zb_VservicesGetAllPricesPeriods() {
+    $result = array();
+    $query = "SELECT * from `vservices`";
+    $all = simple_queryall($query);
+
+    if (!empty($all)) {
+        foreach ($all as $io => $each) {
+            $result[$each['tagid']] = array('price' => $each['price'], 'daysperiod' => $each['charge_period_days']);
+        }
+    }
+
+    return ($result);
+}
+
+/**
  * Returns price summary of all virtual services fees assigned to user
  * 
  * @param string $login
@@ -793,6 +855,49 @@ function zb_VservicesGetUserPrice($login) {
             }
         }
     }
+    return ($result);
+}
+
+/**
+ * Returns all users with assigned virtual services as array:
+ *         login => array($vServiceName1 => vServicePrice1,
+ *                        $vServiceName2 => vServicePrice2,
+ *                        $vServiceNameN => vServicePriceN
+ *                       )
+ * if $includePeriod is true returned array will look like this:
+ *          login => array($vServiceName1 => array('price' => vServicePrice1, 'daysperiod' => vServicePeriod1),
+ *                        $vServiceName2 => array('price' => vServicePrice2, 'daysperiod' => vServicePeriod2),
+ *                        $vServiceNameN => array('price' => vServicePriceN, 'daysperiod' => vServicePeriodN),
+ *                       )
+ *
+ * @param string $login
+ * @param bool $includePeriod
+ *
+ * @return array
+ */
+function zb_VservicesGetUsersAll($login = '', $includePeriod = false) {
+    $result = array();
+    $allUserTags = zb_UserGetAllTags($login);
+
+    //user have some tags assigned
+    if (!empty($allUserTags)) {
+        $vservicePrices = ($includePeriod) ? zb_VservicesGetAllPricesPeriods() : zb_VservicesGetAllPrices();
+
+        foreach ($allUserTags as $eachLogin => $data) {
+            $tmpArr = array();
+
+            foreach ($data as $tagId => $tagName) {
+                if (isset($vservicePrices[$tagId])) {
+                    $tmpArr[$tagName] = $vservicePrices[$tagId];
+                }
+            }
+
+            if (!empty($tmpArr)) {
+                $result[$eachLogin] = $tmpArr;
+            }
+        }
+    }
+
     return ($result);
 }
 

--- a/api/libs/api.workicons.php
+++ b/api/libs/api.workicons.php
@@ -324,4 +324,15 @@ function web_bool_star($flag, $text = false) {
     return($led);
 }
 
+/**
+ * Returns standard edit icon
+ *
+ * @param string $title
+ * @return string
+ */
+function web_clone_icon($title = 'Clone') {
+    $icon = wf_img('skins/duplicate_icon.gif', __($title));
+    return($icon);
+}
+
 ?>

--- a/content/updates/sql/1.0.5.sql
+++ b/content/updates/sql/1.0.5.sql
@@ -18,3 +18,17 @@ ALTER TABLE `frozen_charge_days` ADD `last_freeze_charge_dt` datetime NOT NULL A
 ALTER TABLE `frozen_charge_days` ADD `last_workdays_upd_dt` datetime NOT NULL;
 
 ALTER TABLE `visor_dvrs` ADD `camlimit` int(11) NULL DEFAULT 0 AFTER `type`;
+
+ALTER TABLE `vservices` MODIFY `price` double NOT NULL DEFAULT 0;
+ALTER TABLE `vservices` ADD `charge_period_days` tinyint(3) NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS `invoices` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `login` varchar(50) NOT NULL,
+  `invoice_num` varchar(40) NOT NULL DEFAULT '',
+  `invoice_date` datetime NOT NULL,
+  `invoice_sum` double NOT NULL DEFAULT 0,
+  `invoice_body` text NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY (`invoice_num`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;

--- a/docs/test_dump.sql
+++ b/docs/test_dump.sql
@@ -2709,9 +2709,22 @@ CREATE TABLE IF NOT EXISTS `visor_secrets` (
   `password` varchar(64) DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;
-ALTER TABLE `envydevices` ADD `active` TINYINT NULL DEFAULT '1' AFTER `switchid`;
 
 ALTER TABLE `frozen_charge_days` ADD `last_freeze_charge_dt` datetime NOT NULL AFTER `freeze_days_used`;
 ALTER TABLE `frozen_charge_days` ADD `last_workdays_upd_dt` datetime NOT NULL;
 
 ALTER TABLE `visor_dvrs` ADD `camlimit` int(11) NULL DEFAULT 0 AFTER `type`;
+
+ALTER TABLE `vservices` MODIFY `price` double NOT NULL DEFAULT 0;
+ALTER TABLE `vservices` ADD `charge_period_days` tinyint(3) NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS `invoices` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `login` varchar(50) NOT NULL,
+  `invoice_num` varchar(40) NOT NULL DEFAULT '',
+  `invoice_date` datetime NOT NULL,
+  `invoice_sum` double NOT NULL DEFAULT 0,
+  `invoice_body` text NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY (`invoice_num`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;

--- a/languages/russian/billing.php
+++ b/languages/russian/billing.php
@@ -3141,6 +3141,7 @@ $lang['def']['FDB cache'] = 'Кеш FDB';
 $lang['def']['View full'] = 'Просмотреть полностью';
 $lang['def']['Our profit'] = 'Наша прибыль';
 $lang['def']['Payouts for Megogo'] = 'Выплаты для Megogo';
+$lang['def']['Charge period in days'] = 'Периодичность снятия оплаты в днях';
 $lang['def'][''] = '';
 
 ?>

--- a/languages/ukrainian/billing.php
+++ b/languages/ukrainian/billing.php
@@ -3162,5 +3162,5 @@ $lang['def']['FDB cache'] = 'Кеш FDB';
 $lang['def']['View full'] = 'Переглянути повністю';
 $lang['def']['Our profit'] = 'Наш прибуток';
 $lang['def']['Payouts for Megogo'] = 'Виплати для Megogo';
-
+$lang['def']['Charge period in days'] = 'Періодичність зняття оплати у днях';
 ?>

--- a/modules/general/banksta2/index.php
+++ b/modules/general/banksta2/index.php
@@ -130,28 +130,48 @@ if (cfr('BANKSTA2')) {
         // manipulate fields mapping preset
         if (wf_CheckPost(array('fmpid'))) {
             $fmpID = $_POST['fmpid'];
+            $fmpEdit = wf_CheckPost(array('fmpedit'));
+            $fmpClone = wf_CheckPost(array('fmpclone'));
 
-            // edit fields mapping preset
-            if (wf_CheckPost(array('fmpedit'))) {
+            // edit/clone fields mapping preset
+            if ($fmpEdit or $fmpClone) {
                  if (wf_CheckPost(array('fmpname'))) {
                      $newFMPName = $_POST['fmpname'];
-                     $foundId = $Banksta->checkFMPNameExists($newFMPName, $fmpID);
+                     $foundId = ($fmpClone) ? $Banksta->checkFMPNameExists($newFMPName) : $Banksta->checkFMPNameExists($newFMPName, $fmpID);
 
                      if (empty($foundId)) {
-                         $Banksta->editFieldsMappingPreset($fmpID, $newFMPName, $_POST['fmpcolrealname'], $_POST['fmpcoladdr'], $_POST['fmpcolpaysum'],
-                                                           $_POST['fmpcolpaypurpose'], $_POST['fmpcolpaydate'], $_POST['fmpcolpaytime'], $_POST['fmpcolcontract'],
-                                                          (wf_CheckPost(array('fmptryguesscontract'))) ? 1 : 0,
-                                                           $_POST['fmpcontractdelimstart'], $_POST['fmpcontractdelimend'],
-                                                           $_POST['fmpcontractminlen'], $_POST['fmpcontractmaxlen'], $_POST['fmpsrvtype'],
-                                                           $_POST['fmpinetdelimstart'], $_POST['fmpinetdelimend'], $_POST['fmpinetkeywords'],
-                                                           $_POST['fmpukvdelimstart'], $_POST['fmpukvdelimend'], $_POST['fmpukvkeywords'],
-                                                          (wf_CheckPost(array('fmpskiprow'))) ? 1 : 0,
-                                                           $_POST['fmpcolskiprow'], $_POST['fmpskiprowkeywords'],
-                                                          (wf_CheckPost(array('fmpreplacestrs'))) ? 1 : 0,
-                                                           $_POST['fmpcolsreplacestrs'], $_POST['fmpstrstoreplace'], $_POST['fmpstrstoreplacewith'], $_POST['fmpstrsreplacecount'],
-                                                          (wf_CheckPost(array('fmpremovestrs'))) ? 1 : 0,
-                                                           $_POST['fmpcolsremovestrs'], $_POST['fmpstrstoremove']
-                                                          );
+                         if ($fmpEdit) {
+                             $Banksta->editFieldsMappingPreset($fmpID, $newFMPName, $_POST['fmpcolrealname'], $_POST['fmpcoladdr'], $_POST['fmpcolpaysum'],
+                                                               $_POST['fmpcolpaypurpose'], $_POST['fmpcolpaydate'], $_POST['fmpcolpaytime'], $_POST['fmpcolcontract'],
+                                                               (wf_CheckPost(array('fmptryguesscontract'))) ? 1 : 0,
+                                                               $_POST['fmpcontractdelimstart'], $_POST['fmpcontractdelimend'],
+                                                               $_POST['fmpcontractminlen'], $_POST['fmpcontractmaxlen'], $_POST['fmpsrvtype'],
+                                                               $_POST['fmpinetdelimstart'], $_POST['fmpinetdelimend'], $_POST['fmpinetkeywords'],
+                                                               $_POST['fmpukvdelimstart'], $_POST['fmpukvdelimend'], $_POST['fmpukvkeywords'],
+                                                               (wf_CheckPost(array('fmpskiprow'))) ? 1 : 0,
+                                                               $_POST['fmpcolskiprow'], $_POST['fmpskiprowkeywords'],
+                                                               (wf_CheckPost(array('fmpreplacestrs'))) ? 1 : 0,
+                                                               $_POST['fmpcolsreplacestrs'], $_POST['fmpstrstoreplace'], $_POST['fmpstrstoreplacewith'], $_POST['fmpstrsreplacecount'],
+                                                               (wf_CheckPost(array('fmpremovestrs'))) ? 1 : 0,
+                                                               $_POST['fmpcolsremovestrs'], $_POST['fmpstrstoremove']
+                             );
+                         } elseif ($fmpClone) {
+                             $Banksta->addFieldsMappingPreset($newFMPName, $_POST['fmpcolrealname'], $_POST['fmpcoladdr'], $_POST['fmpcolpaysum'],
+                                                               $_POST['fmpcolpaypurpose'], $_POST['fmpcolpaydate'], $_POST['fmpcolpaytime'], $_POST['fmpcolcontract'],
+                                                               (wf_CheckPost(array('fmptryguesscontract'))) ? 1 : 0,
+                                                               $_POST['fmpcontractdelimstart'], $_POST['fmpcontractdelimend'],
+                                                               $_POST['fmpcontractminlen'], $_POST['fmpcontractmaxlen'], $_POST['fmpsrvtype'],
+                                                               $_POST['fmpinetdelimstart'], $_POST['fmpinetdelimend'], $_POST['fmpinetkeywords'],
+                                                               $_POST['fmpukvdelimstart'], $_POST['fmpukvdelimend'], $_POST['fmpukvkeywords'],
+                                                               (wf_CheckPost(array('fmpskiprow'))) ? 1 : 0,
+                                                               $_POST['fmpcolskiprow'], $_POST['fmpskiprowkeywords'],
+                                                               (wf_CheckPost(array('fmpreplacestrs'))) ? 1 : 0,
+                                                               $_POST['fmpcolsreplacestrs'], $_POST['fmpstrstoreplace'], $_POST['fmpstrstoreplacewith'], $_POST['fmpstrsreplacecount'],
+                                                               (wf_CheckPost(array('fmpremovestrs'))) ? 1 : 0,
+                                                               $_POST['fmpcolsremovestrs'], $_POST['fmpstrstoremove']
+                             );
+                         }
+
                          die();
                      } else {
                          $errormes = $Banksta->getUbMsgHelperInstance()->getStyledMessage(__('Preset with such name already exists with ID: ') . $foundId,
@@ -160,7 +180,7 @@ if (cfr('BANKSTA2')) {
                      }
                  }
 
-                die(wf_modalAutoForm(__('Edit fields mapping preset'), $Banksta->renderFMPEditForm($fmpID, $_POST['modalWindowId']), $_POST['modalWindowId'], $_POST['modalWindowBodyId'], true));
+                die(wf_modalAutoForm(__('Edit fields mapping preset'), $Banksta->renderFMPEditForm($fmpID, $_POST['modalWindowId'], $fmpClone), $_POST['modalWindowId'], $_POST['modalWindowBodyId'], true));
             }
 
             // delete fields mapping preset

--- a/modules/general/vservices/index.php
+++ b/modules/general/vservices/index.php
@@ -1,44 +1,46 @@
 <?php
 if(cfr('VSERVICES')) {
+    if (ubRouting::checkPost('newfee', false)) {
+        $tagid = ubRouting::post('newtagid');
+        $price = ubRouting::post('newfee');
+        $cashtype = ubRouting::post('newcashtype');
+        $priority = ubRouting::post('newpriority');
+        $feechargealways = (ubRouting::post('feechargealways')) ? 1 : 0;
+        $feechargeperiod = (ubRouting::post('newperiod')) ? ubRouting::post('newperiod') : 0;
 
-    if (isset ($_POST['newfee'])) {
-        $tagid = $_POST['newtagid'];
-        $price = $_POST['newfee'];
-        $cashtype = $_POST['newcashtype'];
-        $priority = $_POST['newpriority'];
-        $feechargealways = (wf_CheckPost(array('feechargealways'))) ? 1 : 0;
         if (!empty($price)) {
-        zb_VserviceCreate($tagid, $price, $cashtype, $priority, $feechargealways);
-        rcms_redirect("?module=vservices");
+            zb_VserviceCreate($tagid, $price, $cashtype, $priority, $feechargealways, $feechargeperiod);
+            rcms_redirect("?module=vservices");
         } else {
             show_error(__('No all of required fields is filled'));
         }
     }
-    
-    if (isset($_GET['delete'])) {
-        $vservid=$_GET['delete'];
+
+    if (ubRouting::checkGet('delete')) {
+        $vservid = ubRouting::get('delete');
         zb_VsericeDelete($vservid);
         rcms_redirect("?module=vservices");
     }
     
-    if (wf_CheckGet(array('edit')) ){
-        $editId=vf($_GET['edit'],3);
-        if (wf_CheckPost(array('edittagid', 'editcashtype', 'editpriority', 'editfee'))) {
-            simple_update_field('vservices', 'tagid', $_POST['edittagid'], "WHERE `id`='".$editId."'");
-            simple_update_field('vservices', 'cashtype', $_POST['editcashtype'], "WHERE `id`='".$editId."'");
-            simple_update_field('vservices', 'priority', $_POST['editpriority'], "WHERE `id`='".$editId."'");
-            simple_update_field('vservices', 'price', $_POST['editfee'], "WHERE `id`='".$editId."'");
-            simple_update_field('vservices', 'fee_charge_always', (wf_CheckPost(array('editfeechargealways'))) ? 1 : 0, "WHERE `id`='".$editId."'");
-            log_register("CHANGE VSERVICE [".$editId."] PRICE `".$_POST['editfee']."`");
+    if (ubRouting::checkGet('edit')) {
+        $editId = vf(ubRouting::get('edit'), 3);
+
+        if (ubRouting::checkPost(array('edittagid', 'editcashtype', 'editpriority', 'editfee'))) {
+            $feechargealways = (ubRouting::post('editfeechargealways')) ? 1 : 0;
+            $feechargeperiod = (ubRouting::post('editperiod')) ? ubRouting::post('editperiod') : 0;
+
+            zb_VserviceEdit($editId, ubRouting::post('edittagid'), ubRouting::post('editfee'),
+                            ubRouting::post('editcashtype'), ubRouting::post('editpriority'),
+                            $feechargealways, $feechargeperiod);
+
             rcms_redirect("?module=vservices");
         }
+
         show_window(__('Edit'), web_VserviceEditForm($_GET['edit']));
     } else {
-    //show available services list
+        //show available services list
         web_VservicesShow();
     }
-    
-    
 }
 else {
 	show_error(__('Access denied'));

--- a/modules/remoteapi/vserviceschargefee.php
+++ b/modules/remoteapi/vserviceschargefee.php
@@ -1,21 +1,21 @@
 <?php
-
 /*
  * Virtualservices charge fee
  */
 
-if ($_GET['action'] == 'vserviceschargefee') {
-    if (wf_CheckGet(array('param'))) {
-        if ($_GET['param'] == 'nofrozen') {
-            $vservicesChargeFrozen = false;
-        } else {
-            $vservicesChargeFrozen = true;
-        }
-    } else {
-        $vservicesChargeFrozen = true;
+if (ubRouting::checkGet('action') and ubRouting::get('action') == 'vserviceschargefee') {
+    $vservicesChargeFrozen = (ubRouting::get('param') == 'nofrozen') ? false : true;
+    $vservicesChargePeriod = '';
+
+    if (ubRouting::checkGet('period')) {
+        $periodFilter = str_ireplace('_', ',', ubRouting::get('period'));
+        $vservicesChargePeriod = " WHERE `charge_period_days` IN (" . $periodFilter . ")";
     }
 
-    zb_VservicesProcessAll(true, $vservicesChargeFrozen);
-    log_register("REMOTEAPI VSERVICE_CHARGE_FEE");
+    log_register("REMOTEAPI VSERVICE_CHARGE_FEE STARTED");
+
+    zb_VservicesProcessAll(true, $vservicesChargeFrozen, $vservicesChargePeriod);
+
+    log_register("REMOTEAPI VSERVICE_CHARGE_FEE FINISHED");
     die('OK:SERVICE_CHARGE_FEE');
 }


### PR DESCRIPTION
api.fundsflow.php:
Removed shitty implementation of funds flow array keys uniqueness.

Payfind module:
Added 2 more filters: by city and by strictly assigned contragents. Not sure if a separate alter.ini option is needed for that, but if does - just mention that in a code review.

Virtual services module:
Refactored with ubRouting use.
Added days charge period field which may be used as grouping/filtering mark, e.g. for separate virtual services processing like process some of them monthly and some of them daily, weekly, etc. Also it may be used to include virtual services to invoices and calculate their monthly cost if it's a daily/weekly/etc charged service.
If it'll be better to make a separate alter.ini option for that - just mention that in a code review.

RemoteAPI vservicechargefee call:
Added new parameter "&period" which works like a virtual services filter: you can pass a days charge period value to this parameter and only virtual services with days charge period matching this value will be processed. Useful if you want to have a daily/weekly/monthly/etc processed virtual services in your crontab. You can combine days charge period value separating them with underscore, like: $period=7_10_12. It may sound like nonsense but it's just possible and may be used for grouping or whatever.

api.astral.php:
Added simple helper function

api.workicons.php:
Added web_clone_icon() function

Module Banksta2:
Added ability to clone filed mapping presets
Made some cosmetics to field mapping presets adding and editing