### PR TITLE
Fix PHP Fatal error

### DIFF
--- a/modules/general/genocide/index.php
+++ b/modules/general/genocide/index.php
@@ -20,6 +20,34 @@ if (cfr('GENOCIDE')) {
         $home_band_p = vf($_POST['home_band_p'], 3);
     }
 
+    function gen_create_limit($tariff, $speed) {
+        $tariff = mysql_real_escape_string($tariff);
+        $speed = vf($speed, 3);
+        $query = "INSERT INTO `genocide` (
+            `id` ,
+            `tariff` ,
+            `speed`
+            )
+            VALUES (
+            NULL , '" . $tariff . "', '" . $speed . "'
+            );";
+        nr_query($query);
+        log_register("GENOCIDE ADD " . $tariff);
+    }
+
+    function gen_delete_limit($tariff) {
+        $query = "DELETE from `genocide` WHERE `tariff`='" . $tariff . "'";
+        nr_query($query);
+        log_register("GENOCIDE DELETE " . $tariff);
+    }
+
+    function web_gen_addform() {
+        $addinputs = web_tariffselector();
+        $addinputs .= wf_TextInput('newgenocide', 'Speed', '', false, '10');
+        $addinputs .= wf_Submit('Create');
+        $addform = wf_Form('', 'POST', $addinputs, 'glamour');
+        show_window('', $addform);
+    }
 
 //create or delete limits
     if (isset($_GET['delete'])) {
@@ -122,35 +150,6 @@ if (cfr('GENOCIDE')) {
         $result .= wf_TableBody($tablerows, '100%', '0', 'sortable');
 
         show_window(__('Genocide'), $result);
-    }
-
-    function gen_create_limit($tariff, $speed) {
-        $tariff = mysql_real_escape_string($tariff);
-        $speed = vf($speed, 3);
-        $query = "INSERT INTO `genocide` (
-            `id` ,
-            `tariff` ,
-            `speed`
-            )
-            VALUES (
-            NULL , '" . $tariff . "', '" . $speed . "'
-            );";
-        nr_query($query);
-        log_register("GENOCIDE ADD " . $tariff);
-    }
-
-    function gen_delete_limit($tariff) {
-        $query = "DELETE from `genocide` WHERE `tariff`='" . $tariff . "'";
-        nr_query($query);
-        log_register("GENOCIDE DELETE " . $tariff);
-    }
-
-    function web_gen_addform() {
-        $addinputs = web_tariffselector();
-        $addinputs .= wf_TextInput('newgenocide', 'Speed', '', false, '10');
-        $addinputs .= wf_Submit('Create');
-        $addform = wf_Form('', 'POST', $addinputs, 'glamour');
-        show_window('', $addform);
     }
 
     gen_check_users();


### PR DESCRIPTION
```
[Fri Feb 21 16:21:39.172618 2020] [php7:error] [pid 2676] [client 178.165.X.X:64016] PHP Fatal error:  Uncaught Error: Call to undefined function gen_create_limit() in /var/www/data/billing/modules/general/genocide/index.php:32\nStack trace:\n#0 /var/www/data/billing/index.php(67): include_once()\n#1 {main}\n  thrown in /var/www/data/billing/modules/general/genocide/index.php on line 32, referer: http://billing/?module=genocide
```

Функция вызывается раньше, чем она создается.