### PR TITLE
report finance consider negative payments

### DIFF
--- a/config/alter.ini
+++ b/config/alter.ini
@@ -1003,3 +1003,7 @@ TRASSIRMGR_ENABLED=0
 ;TELEGRAM_DEBUG=1
 ;Enable notes display in taskman spent materials list. Optional option.
 ;WAREHOUSE_TASKMANNOTES=1
+;Determines whether to consider negative payments in finance report.
+;Excludes virtual services, CAP penalties and OTT services(Omega, Trinity, Megogo)
+;Don't turn it on if you not really need it - make payments corrections correctly
+;REPORT_FINANCE_CONSIDER_NEGATIVE=0


### PR DESCRIPTION
Module report finance:
   Added ability to consider negative payments, except virtual services, CAP penalties and OTT services(Omega, Trinity, Megogo)

alter.ini
   Added REPORT_FINANCE_CONSIDER_NEGATIVE non mandatory option