### PR TITLE
banksta2_paynotes_update

### DIFF
--- a/content/updates/sql/1.0.6.sql
+++ b/content/updates/sql/1.0.6.sql
@@ -11,3 +11,16 @@ CREATE TABLE IF NOT EXISTS `invoices` (
   PRIMARY KEY (`id`),
   UNIQUE KEY (`invoice_num`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;
+
+CREATE TABLE IF NOT EXISTS `address_extended` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `login` varchar(50) NOT NULL,
+  `postal_code` varchar(10) NOT NULL DEFAULT '',
+  `town_district` varchar(150) NOT NULL DEFAULT '',
+  `address_exten` varchar(250) NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY (`login`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;
+
+ALTER TABLE `payments` MODIFY `note` varchar(200) NULL DEFAULT NULL;
+ALTER TABLE `paymentscorr` MODIFY `note` varchar(200) NULL DEFAULT NULL;


### PR DESCRIPTION
Module banksta2:
    Update to payments notes: payment date and time from bank statement are now included to payment note, if they are present
    
SQL:
    `note` field for payments and paymentscorr tables extended from varchar(45) to varchar(200) - hope this won't be a trouble?

Если увеличение размера поля `note` до varchar(200) таки проблема - можем ли мы в принципе его увеличть хоть на сколько-то?
Если нет - буду убирать изменения для таблиц payments и paymentscorr.