### PR TITLE
userreg_logingen_and_olt_assign_update

### DIFF
--- a/api/libs/api.userreg.php
+++ b/api/libs/api.userreg.php
@@ -102,6 +102,8 @@ function web_AddressBuildShowAptsCheck($buildid) {
  */
 function web_UserRegFormLocation() {
     global $registerSteps;
+    global $ubillingConfig;
+
     $aptsel = '';
     $servicesel = '';
     $currentStep = 0;
@@ -270,9 +272,9 @@ function zb_RegLoginProposal($cityalias, $streetalias, $buildnum, $apt, $ip_prop
             $busylogins = zb_AllBusyLogins();
             $prefixSize = 4;
             for ($i = 1; $i < 100000; $i++) {
-                $nextIncrementFiveProposal = sprintf('%0' . $prefixSize . 'd', $i);
-                if (!isset($busylogins[$nextIncrementFiveProposal])) {
-                    $result = $nextIncrementFiveProposal;
+                $nextIncrementProposal = sprintf('%0' . $prefixSize . 'd', $i);
+                if (!isset($busylogins[$nextIncrementProposal])) {
+                    $result = $nextIncrementProposal;
                     break;
                 }
             }
@@ -283,9 +285,9 @@ function zb_RegLoginProposal($cityalias, $streetalias, $buildnum, $apt, $ip_prop
             $busylogins = zb_AllBusyLogins();
             $prefixSize = 5;
             for ($i = 1; $i < 100000; $i++) {
-                $nextIncrementFiveProposal = sprintf('%0' . $prefixSize . 'd', $i);
-                if (!isset($busylogins[$nextIncrementFiveProposal])) {
-                    $result = $nextIncrementFiveProposal;
+                $nextIncrementProposal = sprintf('%0' . $prefixSize . 'd', $i);
+                if (!isset($busylogins[$nextIncrementProposal])) {
+                    $result = $nextIncrementProposal;
                     break;
                 }
             }
@@ -296,9 +298,9 @@ function zb_RegLoginProposal($cityalias, $streetalias, $buildnum, $apt, $ip_prop
             $busylogins = zb_AllBusyLogins();
             $prefixSize = 6;
             for ($i = 1; $i < 1000000; $i++) {
-                $nextIncrementFiveProposal = sprintf('%0' . $prefixSize . 'd', $i);
-                if (!isset($busylogins[$nextIncrementFiveProposal])) {
-                    $result = $nextIncrementFiveProposal;
+                $nextIncrementProposal = sprintf('%0' . $prefixSize . 'd', $i);
+                if (!isset($busylogins[$nextIncrementProposal])) {
+                    $result = $nextIncrementProposal;
                     break;
                 }
             }
@@ -309,11 +311,11 @@ function zb_RegLoginProposal($cityalias, $streetalias, $buildnum, $apt, $ip_prop
             $busylogins = zb_AllBusyLogins();
             $prefixSize = 4;
             for ($i = 1; $i < 100000; $i++) {
-
-                $nextIncrementFiveRevProposal = sprintf('%0' . $prefixSize . 'd', $i);
-                $nextIncrementFiveRevProposal = strrev($nextIncrementFiveRevProposal);
-                if (!isset($busylogins[$nextIncrementFiveRevProposal])) {
-                    $result = $nextIncrementFiveRevProposal;
+                //$nextIncrementRevProposal = sprintf('%0' . $prefixSize . 'd', $i);
+                //$nextIncrementRevProposal = strrev($nextIncrementRevProposal);
+                $nextIncrementRevProposal = sprintf('%-0' . $prefixSize . 's', $i);
+                if (!isset($busylogins[$nextIncrementRevProposal])) {
+                    $result = $nextIncrementRevProposal;
                     break;
                 }
             }
@@ -324,11 +326,11 @@ function zb_RegLoginProposal($cityalias, $streetalias, $buildnum, $apt, $ip_prop
             $busylogins = zb_AllBusyLogins();
             $prefixSize = 5;
             for ($i = 1; $i < 100000; $i++) {
-
-                $nextIncrementFiveRevProposal = sprintf('%0' . $prefixSize . 'd', $i);
-                $nextIncrementFiveRevProposal = strrev($nextIncrementFiveRevProposal);
-                if (!isset($busylogins[$nextIncrementFiveRevProposal])) {
-                    $result = $nextIncrementFiveRevProposal;
+                //$nextIncrementRevProposal = sprintf('%0' . $prefixSize . 'd', $i);
+                //$nextIncrementRevProposal = strrev($nextIncrementRevProposal);
+                $nextIncrementRevProposal = sprintf('%-0' . $prefixSize . 's', $i);
+                if (!isset($busylogins[$nextIncrementRevProposal])) {
+                    $result = $nextIncrementRevProposal;
                     break;
                 }
             }
@@ -338,12 +340,12 @@ function zb_RegLoginProposal($cityalias, $streetalias, $buildnum, $apt, $ip_prop
         if ($type == 'INCREMENTSIXREV') {
             $busylogins = zb_AllBusyLogins();
             $prefixSize = 6;
-            for ($i = 1; $i < 100000; $i++) {
-
-                $nextIncrementFiveRevProposal = sprintf('%0' . $prefixSize . 'd', $i);
-                $nextIncrementFiveRevProposal = strrev($nextIncrementFiveRevProposal);
-                if (!isset($busylogins[$nextIncrementFiveRevProposal])) {
-                    $result = $nextIncrementFiveRevProposal;
+            for ($i = 1; $i < 1000000; $i++) {
+                //$nextIncrementRevProposal = sprintf('%0' . $prefixSize . 'd', $i);
+                //$nextIncrementRevProposal = strrev($nextIncrementRevProposal);
+                $nextIncrementRevProposal = sprintf('%-0' . $prefixSize . 's', $i);
+                if (!isset($busylogins[$nextIncrementRevProposal])) {
+                    $result = $nextIncrementRevProposal;
                     break;
                 }
             }
@@ -627,16 +629,17 @@ function web_UserRegFormNetData($newuser_data) {
             $form.= wf_tag('tr', false, 'row3');
             $form.= wf_tag('td', false, '', 'style="text-align: center;" colspan="2"');
             $form.= wf_tag('h3', false, '', 'style="color: #000"');
-            $form .= __('No OLT devices found - can not associate ONU');
+            $form.= __('No OLT devices found - can not associate ONU');
             $form.= wf_tag('h3', true);
-            $form .= wf_tag('td', true);
-            $form .= wf_tag('tr', true);
+            $form.= wf_tag('td', true);
+            $form.= wf_tag('tr', true);
+            $form.= wf_HiddenInput('nooltsfound', 'true');
         } else {
             $form.= wf_tag('tr', false, 'row3');
             $form.= wf_tag('td', false);
-            $form .= wf_Selector('oltid', $allOLTs, '', '', true, false, 'OLTSelector');
-            $form .= wf_tag('script', false, '', 'type="text/javascript"');
-            $form .= '
+            $form.= wf_Selector('oltid', $allOLTs, '', '', true, false, 'OLTSelector');
+            $form.= wf_tag('script', false, '', 'type="text/javascript"');
+            $form.= '
                 $(document).ready(function() {
                     getUnknownONUList($(\'#OLTSelector\').val());
                 });
@@ -830,6 +833,8 @@ function zb_UserRegister($user_data, $goprofile = true) {
     global $billing, $ubillingConfig;
     $billingconf = $ubillingConfig->getBilling();
     $alterconf = $ubillingConfig->getAlter();
+    $registerUserONU = $ubillingConfig->getAlterParam('ONUAUTO_USERREG');
+    $needONUAssignment = false;
 
     // Init all of needed user data
     $login = vf($user_data['login']);
@@ -846,13 +851,13 @@ function zb_UserRegister($user_data, $goprofile = true) {
     $serviceid = $user_data['service'];
 
     //ONU auto assign options
-    if (@$alterconf['ONUAUTO_USERREG']) {
+    if ($registerUserONU and !empty($user_data['oltid'])) {
         $OLTID = $user_data['oltid'];
         $ONUModelID = $user_data['onumodelid'];
         $ONUIP = $user_data['onuip'];
         $ONUMAC = $user_data['onumac'];
         $ONUSerial = $user_data['onuserial'];
-        $NeedONUAssignment = !empty($ONUMAC);
+        $needONUAssignment = !empty($ONUMAC);
     }
 
     if (isset($user_data['userMAC']) and ! empty($user_data['userMAC'])) {
@@ -999,18 +1004,17 @@ function zb_UserRegister($user_data, $goprofile = true) {
     }
 
     // ONU assign for newly created user
-    if (@$alterconf['ONUAUTO_USERREG']) {
-        if ($NeedONUAssignment) {
-            $PONAPIObject = new PONizer();
+    if ($registerUserONU and $needONUAssignment) {
+        $PONAPIObject = new PONizer();
 
-            if ($PONAPIObject->checkMacUnique($ONUMAC)) {
-                $PONAPIObject->onuCreate($ONUModelID, $OLTID, $ONUIP, $ONUMAC, $ONUSerial, $login);
-            } else {
-                $ONUID = $PONAPIObject->getONUIDByMAC($ONUMAC);
-                $PONAPIObject->onuAssign($ONUID, $login);
-            }
+        if ($PONAPIObject->checkMacUnique($ONUMAC)) {
+            $PONAPIObject->onuCreate($ONUModelID, $OLTID, $ONUIP, $ONUMAC, $ONUSerial, $login);
+        } else {
+            $ONUID = $PONAPIObject->getONUIDByMAC($ONUMAC);
+            $PONAPIObject->onuAssign($ONUID, $login);
         }
     }
+
     ///////////////////////////////////
     if ($goprofile) {
         rcms_redirect("?module=userprofile&username=" . $login . '&justregistered=true');

--- a/api/libs/api.userreg.php
+++ b/api/libs/api.userreg.php
@@ -735,20 +735,21 @@ function web_UserRegFormNetData($newuser_data) {
             $form .= wf_tag('a', true);
             $form .= wf_tag('script', false, '', 'type="text/javascript"');
             $form .= '$(\'#onuassignment1\').click(function(evt){
-                if ( typeof( $(\'input[name=onumac]\').val() ) === "string" && $(\'input[name=onumac]\').val().length > 0 ) {
-                    $.ajax({
-                        type: "GET",
-                        url: "?module=userreg",
-                        data: {action:\'checkONUAssignment\', onumac:$(\'input[name=onumac]\').val()},
-                        success: function(result) {
-                                    $(\'#onuassignment2\').text(result);
-                                 }
-                    });
-                } else {$(\'#onuassignment2\').text(\'\');}
-                
-                evt.preventDefault();
-                return false;                
-            });';
+                        evt.preventDefault();
+                        
+                        if ( typeof( $(\'input[name=onumac]\').val() ) === "string" && $(\'input[name=onumac]\').val().length > 0 ) {
+                            $.ajax({
+                                type: "GET",
+                                url: "?module=ponizer",
+                                data: {action:\'checkONUAssignment\', onumac:$(\'input[name=onumac]\').val()},
+                                success: function(result) {
+                                            $(\'#onuassignment2\').text(result);
+                                         }
+                            });
+                        } else {$(\'#onuassignment2\').text(\'\');}
+                       
+                        return false;                
+                    });';
             $form .= wf_tag('script', true);
             $form .= wf_tag('td', true);
             $form .= wf_tag('td', false);

--- a/modules/general/ponizer/index.php
+++ b/modules/general/ponizer/index.php
@@ -166,6 +166,38 @@ if ($altCfg['PON_ENABLED']) {
                 );
             }
         }
+
+        //ONU assigment check
+        if ($_GET['action'] = 'checkONUAssignment' and isset($_GET['onumac'])) {
+            $tString = '';
+            $tStatus = 0;
+            $tLogin = '';
+            $oltData = '';
+            $onuMAC = $_GET['onumac'];
+
+            $ONUAssignment = $pon->checkONUAssignment($pon->getONUIDByMAC($onuMAC), true, true);
+
+            $tStatus = $ONUAssignment['status'];
+            $tLogin = $ONUAssignment['login'];
+            $oltData = $ONUAssignment['oltdata'];
+
+            switch ($tStatus) {
+                case 0:
+                    $tString = __('ONU is not assigned');
+                    break;
+
+                case 1:
+                    $tString = __('ONU is already assigned, but such login is not exists anymore') . '. ' . __('Login') . ': ' . $tLogin . '. OLT: ' . $oltData ;
+                    break;
+
+                case 2:
+                    $tString = __('ONU is already assigned') . '. ' . __('Login') . ': ' . $tLogin . '. OLT: ' . $oltData ;
+                    break;
+
+            }
+
+            die($tString);
+        }
     } else {
         show_error(__('You cant control this module'));
     }

--- a/modules/general/userreg/index.php
+++ b/modules/general/userreg/index.php
@@ -24,32 +24,6 @@ if (cfr('USERREG')) {
         die($Pon->getUnknownONUMACList(vf($_GET['oltid'], 3), true, true, $_GET['selectorid'], $_GET['selectorname']));
     }
 
-    //ONU assigment check
-    if (@$alter_conf['ONUAUTO_USERREG']) {
-        if ($_GET['action'] = 'checkONUAssignment' and isset($_GET['onumac'])) {
-            $PONAPIObject = new PONizer();
-            $ONUMAC = $_GET['onumac'];
-            $ONUAssignment = $PONAPIObject->checkONUAssignment($PONAPIObject->getONUIDByMAC($ONUMAC));
-
-            switch ($ONUAssignment) {
-                case 0:
-                    $tString = __('ONU is not assigned');
-                    break;
-
-                case 1:
-                    $tString = __('ONU is already assigned, but such login is not exists anymore');
-                    break;
-
-                case 2:
-                    $tString = __('ONU is already assigned');
-                    break;
-            }
-
-            echo $tString;
-            die();
-        }
-    }
-
     if ((!isset($_POST['apt'])) AND ( !isset($_POST['IP']))) {
         show_window(__('User registration part 1 (location)'), web_UserRegFormLocation());
     } else {


### PR DESCRIPTION
api.userreg:
   Reverse increment login generation method is changed, because existent implementation may provide leading zeros. Though new implementation was tested on a few production sites I'm asking for a thorough review, if possible. 
   Here is simple piece of code to reproduce the problem:
   
   *****************************************************
   ```
$prefixSize = 6;
   
   for ($i = 1; $i <= 50; $i++) {
       $nextIncrementRevProposal = sprintf('%0' . $prefixSize . 'd', $i);
       $nextIncrementRevProposal = strrev($nextIncrementRevProposal);
   
       print($nextIncrementRevProposal . "\n");
   }
   
   print("\n\n");
   
   for ($i = 1; $i <= 50; $i++) {
       $nextIncrementRevProposal = sprintf('%-0' . $prefixSize . 's', $i);
       print($nextIncrementRevProposal . "\n");
   }
```
   
   *****************************************************
ONU assignment check removed from userreg module and placed into ponizer module.
ONU assignment check function updated to be able to return some additional data.
ONU assignment check button added to create and assign modal form for "User profile" module and "Unknown ONU" module.
Minor improvements to user ONU assignment when there are no OLTs at all yet.