### PR TITLE
easy_sms_template_macro_added

### DIFF
--- a/api/libs/api.banksta2.php
+++ b/api/libs/api.banksta2.php
@@ -115,6 +115,13 @@ class Banksta2 {
     protected $regexKeywordsDelimiter = ',';
 
     /**
+     * Placeholder for BANKSTA2_LSTCHK_FNAMES_TRANSLATE option
+     *
+     * @var bool
+     */
+    protected $translateLstChkFieldNames = false;
+
+    /**
      * Placeholder for file data preprocessed during filePreprocessing()
      *
      * @var array
@@ -170,7 +177,6 @@ class Banksta2 {
      * Routing URLs
      */
     const URL_ME = '?module=banksta2';
-    //const URL_BANKSTA_MGMT = '?module=bankstamd&banksta=true';
     const URL_BANKSTA2_UPLOADFORM = '?module=banksta2&uploadform=true';
     const URL_BANKSTA2_PROCESSING = '?module=banksta2&showhash=';
     const URL_BANKSTA2_DETAILED = '?module=banksta2&showdetailed=';
@@ -231,6 +237,7 @@ class Banksta2 {
         $this->inetPaymentId = $this->ubConfig->getAlterParam('BANKSTA2_PAYMENTID_INET');
         $this->ukvPaymentId = $this->ubConfig->getAlterParam('BANKSTA2_PAYMENTID_UKV');
         $this->regexKeywordsDelimiter = (wf_getBoolFromVar($this->ubConfig->getAlterParam('BANKSTA2_REGEX_KEYWORDS_DELIM'))) ? $this->ubConfig->getAlterParam('BANKSTA2_REGEX_KEYWORDS_DELIM') : ',';
+        $this->translateLstChkFieldNames = $this->ubConfig->getAlterParam('BANKSTA2_LSTCHK_FNAMES_TRANSLATE');
     }
 
 
@@ -1842,16 +1849,38 @@ class Banksta2 {
      * @param $dataRows
      */
     public function web_LastChecksForm($dataRows) {
+        if ($this->translateLstChkFieldNames) {
+            $captContract   = __('Contract');
+            $captSumm       = __('Sum');
+            $captAddr       = __('Address');
+            $captRealName   = __('Real name');
+            $captNotes      = __('Payment notes');
+            $captPDate      = __('Payment date');
+            $captPTime      = __('Payment time');
+            $captSrvType    = __('Service type');
+            $captCanceled   = __('Processing canceled');
+        } else {
+            $captContract   = '[contract]';
+            $captSumm       = '[summ]';
+            $captAddr       = '[address]';
+            $captRealName   = '[realname]';
+            $captNotes      = '[notes]';
+            $captPDate      = '[pdate]';
+            $captPTime      = '[ptime]';
+            $captSrvType    = '[service_type]';
+            $captCanceled   = '[row_canceled]';
+        }
+
         $cells = wf_TableCell('#');
-        $cells.= wf_TableCell('[contract]');
-        $cells.= wf_TableCell('[summ]');
-        $cells.= wf_TableCell('[address]');
-        $cells.= wf_TableCell('[realname]');
-        $cells.= wf_TableCell('[notes]');
-        $cells.= wf_TableCell('[pdate]');
-        $cells.= wf_TableCell('[ptime]');
-        $cells.= wf_TableCell('[service_type]');
-        $cells.= wf_TableCell('[row_canceled]');
+        $cells.= wf_TableCell($captContract);
+        $cells.= wf_TableCell($captSumm);
+        $cells.= wf_TableCell($captAddr);
+        $cells.= wf_TableCell($captRealName);
+        $cells.= wf_TableCell($captNotes);
+        $cells.= wf_TableCell($captPDate);
+        $cells.= wf_TableCell($captPTime);
+        $cells.= wf_TableCell($captSrvType);
+        $cells.= wf_TableCell($captCanceled);
 
         $rows = wf_TableRow($cells, 'row1');
         $table = wf_TableBody($rows . $dataRows, '100%', '0', '');

--- a/api/libs/api.userprofile.php
+++ b/api/libs/api.userprofile.php
@@ -1138,7 +1138,18 @@ class UserProfile {
                                 } else {
                                     $smsText = $templateData;
                                     $smsText = str_ireplace('{LOGIN}', $this->login, $smsText);
-                                    $smsText = str_ireplace('{PASSWORD}', $this->userdata['Password'], $smsText);
+                                    $smsText = str_ireplace('{PASSWORD}', $this->AllUserData[$this->login]['Password'], $smsText);
+                                    $smsText = str_ireplace('{TARIFF}', $this->AllUserData[$this->login]['Tariff'], $smsText);
+                                    $smsText = str_ireplace('{TARIFFPRICE}', zb_TariffGetPrice($this->AllUserData[$this->login]['Tariff']), $smsText);
+                                    $smsText = str_ireplace('{CASH}', $this->AllUserData[$this->login]['Cash'], $smsText);
+                                    $smsText = str_ireplace('{ROUNDCASH}', round($this->AllUserData[$this->login]['Cash'], 2), $smsText);
+                                    $smsText = str_ireplace('{CONTRACT}', $this->contract, $smsText);
+                                    $smsText = str_ireplace('{REALNAME}', $this->realname, $smsText);
+                                    $smsText = str_ireplace('{ADDRESS}', $this->AllUserData[$this->login]['fulladress'], $smsText);
+                                    $smsText = str_ireplace('{PAYID}', $this->paymentid, $smsText);
+                                    $smsText = str_ireplace('{IP}', $this->AllUserData[$this->login]['ip'], $smsText);
+                                    $smsText = str_ireplace('{MAC}', $this->mac, $smsText);
+                                    $smsText = str_ireplace('{CURDATE}', curdate(), $smsText);
                                 }
                             }
 

--- a/config/alter.ini
+++ b/config/alter.ini
@@ -1013,7 +1013,7 @@ TRASSIRMGR_ENABLED=0
 AUTOCREDIT_CFID=0
 ;Enable a quick way to fill EASY_SMS body with predefined template text.
 ;SMS template for that can be found in content/documents/easy_sms_template/easy_sms.tpl.
-;Login/password macro supported there. BTW, EASY_SMS option must be on.
+;All supported macro are listed in the initial template. BTW, EASY_SMS option must be on.
 ;EASY_SMS_QUICK_TEMPLATE=0
 ;Only this administrators list now have right to do balance corrections/set/mock. Optional option.
 CAN_TOUCH_MONEY=""
@@ -1025,3 +1025,5 @@ WIKI_URL=""
 ADDRESS_EXTENDED_ENABLED=0
 ;Enables UserSide fast navigation from black magic in user profile. Possible find_typer can be: abon_dog, abon_code, abon_codeti. Optional option.
 ;USERSIDE_NAV="https://demo.userside.eu/oper/?find_typer=abon_dog"
+;Enables translation for column names in banksta2 last checks
+;BANKSTA2_LSTCHK_FNAMES_TRANSLATE=0

--- a/content/documents/easy_sms_template/easy_sms.tpl
+++ b/content/documents/easy_sms_template/easy_sms.tpl
@@ -1,3 +1,14 @@
 Vash login: {LOGIN}
 Vash parol: {PASSWORD}
+Vash tarif: {TARIFF}
+Stoimost tarifa: {TARIFFPRICE}
+Vash balans: {CASH}
+Vash balans2: {ROUNDCASH}
+Vash dogovor: {CONTRACT}
+FIO: {REALNAME}
+Address: {ADDRESS}
+Vash platezhny ID: {PAYID}
+Vash IP: {IP}
+Vash MAC: {MAC}
+{CURDATE}
 www.your.isp

--- a/languages/russian/banksta2.php
+++ b/languages/russian/banksta2.php
@@ -101,5 +101,6 @@ $lang['def']['select "Telepathy" to try to get service type from payment purpose
 $lang['def']['Payment type ID'] = 'ID типа оплат';
 $lang['def']['Char replacing'] = 'Замена символов';
 $lang['def']['Char removing'] = 'Удаление символов';
+$lang['def']['Processing canceled'] = 'Исключено из обработки';
 $lang['def'][''] = '';
 ?>

--- a/languages/ukrainian/banksta2.php
+++ b/languages/ukrainian/banksta2.php
@@ -102,5 +102,6 @@ $lang['def']['select "Telepathy" to try to get service type from payment purpose
 $lang['def']['Payment type ID'] = 'ID типу оплат';
 $lang['def']['Char replacing'] = 'Заміна символів';
 $lang['def']['Char removing'] = 'Видалення символів';
+$lang['def']['Processing canceled'] = 'Виключено з обробки';
 $lang['def'][''] = '';
 ?>


### PR DESCRIPTION
Added a few more macro to easy SMS template.

module banksta2:
    Added translations for last check form field captions.
     
alter.ini:
    New non-mandatory option BANKSTA2_LSTCHK_FNAMES_TRANSLATE to control last check form field captions translations.