### PR TITLE
banksta2_bugfixes

### DIFF
--- a/api/libs/api.banksta2.php
+++ b/api/libs/api.banksta2.php
@@ -2073,7 +2073,7 @@ class Banksta2 {
                                     $cashPairs[$eachRec['id']]['summ'] = $eachRec['summ'];
                                     $cashPairs[$eachRec['id']]['pdate'] = $eachRec['pdate'];
                                     $cashPairs[$eachRec['id']]['ptime'] = $eachRec['ptime'];
-                                    $cashPairs[$eachRec['id']]['payid'] = $this->inetPaymentId;
+                                    $cashPairs[$eachRec['id']]['payid'] = (empty($eachRec['payid'])) ? $this->inetPaymentId : $eachRec['payid'];
                                     $cashPairs[$eachRec['id']]['service'] = $serviceType;
 
                                     $fiscalRecsIDsList[] = $eachRec['id'];
@@ -2105,7 +2105,7 @@ class Banksta2 {
                                     $cashPairs[$eachRec['id']]['summ'] = $eachRec['summ'];
                                     $cashPairs[$eachRec['id']]['pdate'] = $eachRec['pdate'];
                                     $cashPairs[$eachRec['id']]['ptime'] = $eachRec['ptime'];
-                                    $cashPairs[$eachRec['id']]['payid'] = $this->ukvPaymentId;
+                                    $cashPairs[$eachRec['id']]['payid'] = (empty($eachRec['payid'])) ? $this->ukvPaymentId : $eachRec['payid'];
                                     $cashPairs[$eachRec['id']]['service'] = $serviceType;
 
                                     $fiscalRecsIDsList[] = $eachRec['id'];

--- a/modules/general/banksta2/index.php
+++ b/modules/general/banksta2/index.php
@@ -99,7 +99,7 @@ if (cfr('BANKSTA2')) {
                                                          mysql_real_escape_string($_POST['bsstrstoreplacewith']),  mysql_real_escape_string($_POST['bsreplacementscnt']),
                                                         (wf_CheckPost(array('bsremovestrs'))) ? 1 : 0,
                                                          mysql_real_escape_string($_POST['bscolremovestrs']),  mysql_real_escape_string($_POST['bsstrstoremove']),
-                                                         $_POST['fmppaymtypeid']
+                                                         $_POST['bspaymtypeid']
                                                         );
                     } else {
                         $Banksta->addFieldsMappingPreset($newFMPName, $_POST['fmpcolrealname'], $_POST['fmpcoladdr'], $_POST['fmpcolpaysum'],

--- a/modules/remoteapi/asterisk.php
+++ b/modules/remoteapi/asterisk.php
@@ -13,7 +13,9 @@
  * With "setcredit" param you'll need to pass "login", "money" and "expiredays" params as well
  * With "paycardpay" param you'll need to pass "login", "paycardnum", "paycardcashtype" param as well
  * With "getuserdatabylogin" param you may pass "userpass" param as well to enable user + password verification
- * "getuserdatabymobile", "getcontractsbymobile" and "addusermobile" need no additional parameters except the mobile passed in "number" param
+ * With "addusermobile" param you'll need to pass "login" param also. Optional "maxmobilesamnt" param can be passed to determine
+ * the max mobiles count threshold per user.
+ * "getuserdatabymobile" and "getcontractsbymobile" need no additional parameters except the mobile passed in "number" param
  *
  */
 


### PR DESCRIPTION
Module banksta2:
   Individual payment type IDs for every single template and/or bank statement now actually works.
   Quick field mapping templates can be created again.