### PR TITLE
print_receipt_update_missing_alterini_opt

### DIFF
--- a/api/libs/api.printreceipt.php
+++ b/api/libs/api.printreceipt.php
@@ -44,7 +44,7 @@ class PrintReceipt {
     public $receiptsHistoryOn = false;
 
     /**
-     * Placeholder for PRINT_RECEIPTS_HISTORY_ENABLED alter.ini option
+     * Placeholder for ADDRESS_EXTENDED_ENABLED alter.ini option
      *
      * @var bool
      */

--- a/config/alter.ini
+++ b/config/alter.ini
@@ -1049,3 +1049,5 @@ BLITZORTUNG_URL=""
 USERREG_FREEIP_STATS=0
 ;Cash type ID for payments pushed via UserSide API
 USERSIDE_CASHTYPE=1
+;Enables ability to save receipts to DB
+;PRINT_RECEIPTS_HISTORY_ENABLED=0


### PR DESCRIPTION
alter.ini:
    New non-mandatory option PRINT_RECEIPTS_HISTORY_ENABLED to control the ability of storing receipts in DB