### PR TITLE
banksta2_update

### DIFF
--- a/config/alter.ini
+++ b/config/alter.ini
@@ -1059,3 +1059,5 @@ FILESTORAGE_ENABLED=0
 SW_CASH_ENABLED=0
 ;Is PON ONU search enabled?
 PON_ONU_SEARCH_ENABLED=0
+;Use virtual ID from `op_customers` as payment ID instead of contract, if user's contract is empty
+;BANKSTA2_OPAYZID_AS_CONTRACT=0


### PR DESCRIPTION
Banksta2:
    From now on has an ability to use OPENPAYZ virtual IDs(`virtualid` field from `op_customers`) as payment IDs(contracts). This feature is controlled by new non-mandatory alter.ini option: BANKSTA2_OPAYZID_AS_CONTRACT.