### PR TITLE
Add Zabbix problem for host in user profile

### DIFF
--- a/api/libs/api.networking.php
+++ b/api/libs/api.networking.php
@@ -2173,13 +2173,13 @@ function getZabbixProblems($switchIP) {
 
     if (!empty($switchIP) AND ! empty($zbxAuthToken)) {
         /* Selectd problem level severities
-            Возможные значения:
-            0 - не классифицировано;
-            1 - информационный;
-            2 - предупреждение;
-            3 - средняя;
-            4 - высокая;
-            5 - чрезвычайная.
+            Possible values:
+             0 - not classified;
+             1 - informational;
+             2 - warning;
+             3 - medium;
+             4 - high;
+             5 - emergency.
         */
         if ($ubillingConfig->getAlterParam('ZABBIX_PROBLEM_SEVERITIES')) {
             $severities = explode(',', $ubillingConfig->getAlterParam('ZABBIX_PROBLEM_SEVERITIES'));

--- a/api/libs/api.userprofile.php
+++ b/api/libs/api.userprofile.php
@@ -937,6 +937,21 @@ class UserProfile {
     }
 
     /**
+     * gets zabbix profile controls
+     * 
+     * @return string
+     */
+    protected function getZabbixProblemControls() {
+//zabbix section
+        if ($this->ubConfig->getAlterParam('ZABBIX_PROBLEM_IN_PROFILE')) {
+            $result.= web_ProfileSwitchZabbixProblem($this->login);
+        } else {
+            $result = '';
+        }
+        return ($result);
+    }
+
+    /**
      * Returns user Vlan assign controls
      * 
      * @return string
@@ -1908,6 +1923,8 @@ class UserProfile {
         $profile .= wf_tag('table', true); //end of all profile container
 //profile switch port controls
         $profile .= $this->getSwitchAssignControls();
+//profile zabbix problen controls
+        $profile .= $this->getZabbixProblemControls();
 //profile onu signal controls
         $profile .= $this->getPonSignalControl();
 //profile vlan controls

--- a/api/libs/api.userprofile.php
+++ b/api/libs/api.userprofile.php
@@ -944,7 +944,7 @@ class UserProfile {
     protected function getZabbixProblemControls() {
 //zabbix section
         if ($this->ubConfig->getAlterParam('ZABBIX_PROBLEM_IN_PROFILE')) {
-            $result.= web_ProfileSwitchZabbixProblem($this->login);
+            $result = web_ProfileSwitchZabbixProblem($this->login);
         } else {
             $result = '';
         }


### PR DESCRIPTION
- добавлено отображение проблем с Zabbix по привязанному оборудованию в профиле.

Включается не обязательной опцией alter.ini `ZABBIX_PROBLEM_IN_PROFILE=1`
Добавлена не обязательная опция  alter.ini `ZABBIX_PROBLEM_SEVERITIES=4,5` - фильтрующая проблемы по уровням важности. Уровни проблем указываются через запятую:
            Возможные значения:

> 0 - не классифицировано;
            1 - информационный;
            2 - предупреждение;
            3 - средняя;
            4 - высокая;
            5 - чрезвычайная.
