### PR TITLE
RoS_PPPoE_status_in_profile

### DIFF
--- a/api/libs/api.dealwithit.php
+++ b/api/libs/api.dealwithit.php
@@ -1184,6 +1184,11 @@ class DealWithIt {
         $cells .= wf_TableCell(wf_Selector('dealwithit_search[tariff]', $tariffs_options, '', '', false));
         $rows .= wf_TableRow($cells, 'row2');
 
+        $cells = wf_TableCell(__('Tariff contains'));
+        $cells .= wf_TableCell(wf_CheckInput('dealwithit_search[search_by][tariff_contains]', '', false));
+        $cells .= wf_TableCell(wf_TextInput('dealwithit_search[tariff_contains]', '', '', ''));
+        $rows .= wf_TableRow($cells, 'row2');
+
         $cells = wf_TableCell(__('Status'));
         $cells .= wf_TableCell(wf_CheckInput('dealwithit_search[search_by][user_status]', '', false));
         $cells .= wf_TableCell(wf_Selector('dealwithit_search[user_status]', $param_selector_status, '', '', false));
@@ -1221,6 +1226,11 @@ class DealWithIt {
         $cells_ex = wf_TableCell(__('Tariff'));
         $cells_ex .= wf_TableCell(wf_CheckInput('dealwithit_search[exclude][ex_tariff]', '', false));
         $cells_ex .= wf_TableCell(wf_Selector('dealwithit_search[ex_tariff]', $tariffs_options, '', '', false));
+        $rows_ex .= wf_TableRow($cells_ex, 'row2');
+
+        $cells_ex = wf_TableCell(__('Tariff contains'));
+        $cells_ex .= wf_TableCell(wf_CheckInput('dealwithit_search[exclude][ex_tariff_contains]', '', false));
+        $cells_ex .= wf_TableCell(wf_TextInput('dealwithit_search[ex_tariff_contains]', '', '', ''));
         $rows_ex .= wf_TableRow($cells_ex, 'row2');
 
         $cells_ex = wf_TableCell(__('Status'));
@@ -1282,6 +1292,16 @@ class DealWithIt {
         // Search login by Tariff
         if (isset($search_field['tariff']) and $search_field['tariff'] == 'on') {
             $query = "SELECT `login` FROM `users` WHERE `Tariff` = '" . $_POST['dealwithit_search']['tariff'] . "'";
+            $data_tariff = simple_queryall($query);
+            if (!empty($data_tariff)) {
+                foreach ($data_tariff as $login) {
+                    $result[] = $login['login'];
+                }
+            }
+        }
+        // Search login by Tariff contains string
+        if (isset($search_field['tariff_contains']) and $search_field['tariff_contains'] == 'on') {
+            $query = "SELECT `login` FROM `users` WHERE `Tariff` LIKE '%" . $_POST['dealwithit_search']['tariff_contains'] . "%'";
             $data_tariff = simple_queryall($query);
             if (!empty($data_tariff)) {
                 foreach ($data_tariff as $login) {
@@ -1392,6 +1412,16 @@ class DealWithIt {
         //  Exclude login from request by Tariff
         if (isset($exclude_field['ex_tariff']) and $exclude_field['ex_tariff'] == 'on') {
             $query = "SELECT `login` FROM `users` WHERE `Tariff` = '" . $_POST['dealwithit_search']['ex_tariff'] . "'";
+            $data_tariff = simple_queryall($query);
+            if (!empty($data_tariff)) {
+                foreach ($data_tariff as $login) {
+                    $result_exclude[] = $login['login'];
+                }
+            }
+        }
+        // Search login by Tariff contains string
+        if (isset($exclude_field['ex_tariff_contains']) and $exclude_field['ex_tariff_contains'] == 'on') {
+            $query = "SELECT `login` FROM `users` WHERE `Tariff` LIKE '%" . $_POST['dealwithit_search']['ex_tariff_contains'] . "%'";
             $data_tariff = simple_queryall($query);
             if (!empty($data_tariff)) {
                 foreach ($data_tariff as $login) {

--- a/api/libs/api.networking.php
+++ b/api/libs/api.networking.php
@@ -2289,4 +2289,24 @@ function multinet_get_network_cidr_from_descr($netID) {
 
     return($networkCIDR);
 }
+
+/**
+ * Simply gathers some network-essential info about user, like netID and NAS data
+ *
+ * @param $login
+ *
+ * @return array
+ */
+function getNASInfoByLogin($login) {
+    $tQuery = "SELECT `login`, `ip`, `tNases`.`netid`, `tNases`.`nasip`, `tNases`.`nastype`, `tNases`.`options`
+                    FROM `users`
+                    LEFT JOIN
+                      (SELECT `nethosts`.`netid`, `nethosts`.`ip`, `nas`.`netid` AS `nas_netid`, `nas`.`nasip`, `nas`.`nastype`, `nas`.`options`
+                        FROM `nethosts`
+                            LEFT JOIN `nas` ON `nas`.`netid` = `nethosts`.`netid`) AS tNases USING(`ip`)                
+                    WHERE  `users`.`login` = '" . $login . "'";
+    $tQueryResult = simple_query($tQuery);
+
+    return ($tQueryResult);
+}
 ?>

--- a/api/libs/api.userprofile.php
+++ b/api/libs/api.userprofile.php
@@ -1652,6 +1652,20 @@ class UserProfile {
         return $row;
     }
 
+    /**
+     * Returns spoiler block with user's active PPPoE session data
+     *
+     * @return string
+     */
+    protected function getROSPPPoESessionData() {
+        $row = '';
+
+        if ($this->ubConfig->getAlterParam('ROS_NAS_PPPOE_SESSION_INFO_IN_PROFLE')) {
+            $row = zb_RenderROSPPPoESessionInfo($this->login, '?module=userprofile');
+        }
+
+        return ($row);
+    }
 
     /**
      * Returns users data export allowance trigger if appropriate alter.ini option is set
@@ -2095,6 +2109,8 @@ class UserProfile {
         $profile .= $this->getVlanOnline();
 //profile qinq controls        
         $profile .= $this->getQinqPairControls();
+// profile RoS PPPoE session info
+        $profile .= $this->getROSPPPoESessionData();
 //profile CPE controls
         $profile .= $this->getUserCpeControls();
 
@@ -2131,7 +2147,6 @@ class UserProfile {
 
         return($profile);
     }
-
 }
 
 ?>

--- a/config/alter.ini
+++ b/config/alter.ini
@@ -1105,3 +1105,5 @@ RFCORPS=0
 ;USERS_DATA_EXPORT_ON=0
 ;Consider virtual services in funds flow routines, e.g. calculating days online remaining. Optional option.
 ;FUNDSFLOW_CONSIDER_VSERVICES=0
+;Creates Mikrotik PPPoE session info spoiler in user's profile
+;ROS_NAS_PPPOE_SESSION_INFO_IN_PROFLE=0

--- a/languages/russian/billing.php
+++ b/languages/russian/billing.php
@@ -3211,6 +3211,7 @@ $lang['def']['Dedicated field with services IDs idents mapped via BANKSTA2_INETS
 $lang['def']['Dedicated field with services IDs idents takes precedence over service type telepathy'] = 'ИД сервисов из выделенного поля имеют преимущество перед телепатией сервисов';
 $lang['def']['NOTE: dedicated field\'s services IDs are always take precedence over manually chosen \'Internet\' or \'UKV\' services'] = 'ПРИМЕЧАНИЕ: ИД сервисов из выделенного поля всегда имеют преимущество перед выбранным вручную \'Интернет\' или \'УКВ\' сервисом';
 $lang['def']['Agree'] = 'Согласен';
+$lang['def']['Tariff contains'] = 'Тариф содержит';
 $lang['def'][''] = '';
 
 

--- a/languages/russian/userprofile.php
+++ b/languages/russian/userprofile.php
@@ -1,0 +1,14 @@
+<?php
+$lang['def']['Current user login was not found on NAS'] = 'Пользователь с таким логином не найден на сервере NAS';
+$lang['def']['No active session was found for current user on NAS'] = 'Для текущего пользоветля не найдено активных сессий на сервере NAS';
+$lang['def']['No data'] = 'Нет данных';
+$lang['def']['User has no network and NAS assigned or user\'s NAS is not of type "Mikrotik"'] = 'Пользователю не назначены услуги и сервер NAS или тип сервера NAS пользователя не "Mikrotik"';
+$lang['def']['Unable to connect to user\'s NAS'] = 'Невозможно подключиться к серверу NAS';
+$lang['def']['Error while getting data'] = 'Ошибка при получении данных';
+$lang['def']['last logged out'] = 'дата последнего "logout"';
+$lang['def']['session uptime'] = 'аптайм сессии';
+$lang['def']['last link up time'] = 'дата последнего "link up"';
+$lang['def']['Current user\'s address lists'] = 'Адрес-листы текущего пользователя';
+$lang['def']['session info'] = 'информация о сессии';
+$lang['def']['get session info for current user'] = 'получить информацию о сессии для текущего пользователя';
+$lang['def'][''] = '';

--- a/languages/ukrainian/billing.php
+++ b/languages/ukrainian/billing.php
@@ -3232,6 +3232,7 @@ $lang['def']['Dedicated field with services IDs idents mapped via BANKSTA2_INETS
 $lang['def']['Dedicated field with services IDs idents takes precedence over service type telepathy'] = 'ІД сервісів з виділеного поля мають перевагу перед телепатією сервісів';
 $lang['def']['NOTE: dedicated field\'s services IDs are always take precedence over manually chosen \'Internet\' or \'UKV\' services'] = 'ПРИМІТКА: ІД сервісів з виділеного поля завжди мають перевагу перед обраним вручну \'Інтернет\' чи \'УКВ\' сервісом';
 $lang['def']['Agree'] = 'Згоден';
+$lang['def']['Tariff contains'] = 'Тариф містить';
 $lang['def'][''] = '';
 
 

--- a/languages/ukrainian/userprofile.php
+++ b/languages/ukrainian/userprofile.php
@@ -1,0 +1,14 @@
+<?php
+$lang['def']['Current user login was not found on NAS'] = 'Користувача з таким логіном не знайдено на сервері NAS';
+$lang['def']['No active session was found for current user on NAS'] = 'Для поточного користувача не знайдено активних сесій на сервері NAS';
+$lang['def']['No data'] = 'Нема даних';
+$lang['def']['User has no network and NAS assigned or user\'s NAS is not of type "Mikrotik"'] = 'Користувачу не присвоєні послуги і сервер NAS або тип серверу NAS користувача не "Mikrotik"';
+$lang['def']['Unable to connect to user\'s NAS'] = 'Неможливо підключитися до серверу NAS';
+$lang['def']['Error while getting data'] = 'Помилка при отриманні даних';
+$lang['def']['last logged out'] = 'дата останнього "logout"';
+$lang['def']['session uptime'] = 'аптайм сесії';
+$lang['def']['last link up time'] = 'дата останнього "link up"';
+$lang['def']['Current user\'s address lists'] = 'Адрес-лісти поточного користувача';
+$lang['def']['session info'] = 'інформація про сесію';
+$lang['def']['get session info for current user'] = 'отримати інформацію про сесію для поточного користувача';
+$lang['def'][''] = '';

--- a/modules/general/userprofile/index.php
+++ b/modules/general/userprofile/index.php
@@ -1,6 +1,13 @@
 <?php
 
 if (cfr('USERPROFILE')) {
+    if ($ubillingConfig->getAlterParam('ROS_NAS_PPPOE_SESSION_INFO_IN_PROFLE')) {
+        if (ubRouting::checkPost('GetPPPoEInfo') and ubRouting::checkPost('usrlogin')) {
+            $infoBlock = zb_GetROSPPPoESessionInfo(ubRouting::post('usrlogin'), wf_getBoolFromVar(ubRouting::post('returnAsHTML'), true), wf_getBoolFromVar(ubRouting::post('returnInSpoiler'), true));
+            die($infoBlock);
+        }
+    }
+
     if (isset($_GET['username'])) {
         $login = vf($_GET['username']);
         $login = trim($login);


### PR DESCRIPTION
Module dealwithit:
    Added ability to search/exclude users with a part of tariff name, like "tariff contains"
    
Module userprofile
    Added ability to get data about user's PPPoE session on Mikrotik NAS in a separate block under spoiler
    
alter.ini
    New non-mandatory option ROS_NAS_PPPOE_SESSION_INFO_IN_PROFLE which controls displaying of user's RoS PPPoE session data block
    
Added necessary translations