### PR TITLE
mysql_update_fatal_bug_fix

### DIFF
--- a/docs/presets/FreeBSD/etc/stargazer/mysql.php
+++ b/docs/presets/FreeBSD/etc/stargazer/mysql.php
@@ -1,6 +1,6 @@
 <?php
-$config=parse_ini_file(dirname(__FILE__)."/config");
-$dbport = (empty($this->config['port'])) ? 3306 : $this->config['port'];
+$config = parse_ini_file(dirname(__FILE__)."/config");
+$dbport = (empty($config['port'])) ? 3306 : $config['port'];
 
 if (extension_loaded('mysqli')) {
     $loginDB = new mysqli($config['host'], $config['username'], $config['password'], $config['database'], $dbport);


### PR DESCRIPTION
Fixed "PHP Fatal error:  Using $this when not in object context" critical bug for FreeBSD mysql-wrapper