### PR TITLE
cess_exten_info_dealwithit_fix

### DIFF
--- a/api/libs/api.dealwithit.php
+++ b/api/libs/api.dealwithit.php
@@ -1126,6 +1126,7 @@ class DealWithIt {
             'active' => __('Active'),
             'AlwaysOnline' => __('Always Online'),
             'inactive' => __('Inactive'),
+            'down' => __('Disconnected'),
             'frozen' => __('Frozen'),
         );
         // Load tariffs
@@ -1323,6 +1324,9 @@ class DealWithIt {
                         $where = "`AlwaysOnline` ='1'";
                         break;
                     case 'inactive':
+                        $where = "`Cash` < -`Credit`  ";
+                        break;
+                    case 'down':
                         $where = "`Down` ='1'";
                         break;
                     case 'frozen':
@@ -1443,6 +1447,9 @@ class DealWithIt {
                         $where = "`AlwaysOnline` ='1'";
                         break;
                     case 'inactive':
+                        $where = "`Cash` < -`Credit`  ";
+                        break;
+                    case 'down':
                         $where = "`Down` ='1'";
                         break;
                     case 'frozen':

--- a/config/alter.ini
+++ b/config/alter.ini
@@ -1137,3 +1137,5 @@ OPT82_ENABLED=0
 DAYX_ENABLED=0
 ;Enables displaying of some extended info in switches FDB, like VLAN, iface description and so on. Optional option.
 ;SW_FDB_EXTEN_INFO=0
+;Allows to store some external info about contragent and services and service codes. Can cooperate with Banksta2. Optional option.
+;AGENTS_EXTINFO_ON=0

--- a/modules/general/contrahens/index.php
+++ b/modules/general/contrahens/index.php
@@ -5,7 +5,7 @@ if (cfr('AGENTS')) {
     $alter_conf = $ubillingConfig->getAlter();
 
     //if deleting agent
-    if (ubRouting::checkGet('delete', false)) {
+    if (ubRouting::checkGet('delete', false) and !ubRouting::checkGet('extinfo')) {
         zb_ContrAhentDelete(ubRouting::get('delete'));
         ubRouting::nav("?module=contrahens");
     }
@@ -27,7 +27,7 @@ if (cfr('AGENTS')) {
         ubRouting::nav("?module=contrahens");
     }
 
-    if (ubRouting::checkGet('edit', false)) {
+    if (ubRouting::checkGet('edit', false) and !ubRouting::checkGet('extinfo')) {
 
         //if someone changing agent
         if (ubRouting::post('changecontrname')) {
@@ -50,8 +50,31 @@ if (cfr('AGENTS')) {
         show_window('', wf_BackLink('?module=contrahens'));
     }
 
+    // show or manipulate extended agent info
+    if (ubRouting::checkGet('extinfo')) {
+        // edit extended agent info
+        if (ubRouting::checkPost('extinfeditmode') and ubRouting::checkPost('extinfrecid') and ubRouting::checkPost('extinfagentid')) {
+            zb_EditAgentExtInfoRec(ubRouting::post('extinfrecid'), ubRouting::post('extinfagentid'),
+                                   ubRouting::post('extinfsrvtype'), ubRouting::post('extinfintpaysysname'),
+                                   ubRouting::post('extinfintpaysysid'), ubRouting::post('extinfintpaysyssrvid')
+                                  );
+        } elseif (ubRouting::checkPost('extinfeditmode', false) and ubRouting::checkPost('extinfagentid')) {
+            zb_CreateAgentExtInfoRec(ubRouting::post('extinfagentid'), ubRouting::post('extinfsrvtype'),
+                                     ubRouting::post('extinfintpaysysname'), ubRouting::post('extinfintpaysysid'),
+                                     ubRouting::post('extinfintpaysyssrvid')
+                                    );
+        }
+
+        show_window(__('Extended info'),
+                    zb_RenderAgentExtInfoTable(ubRouting::get('extinfo')) .
+                    wf_delimiter() .
+                    (ubRouting::checkGet('edit') ? zb_AgentEditExtInfoForm(ubRouting::checkGet('edit')) : zb_AgentEditExtInfoForm()) .
+                    wf_delimiter() .
+                    wf_BackLink('?module=contrahens'));
+    }
+
     //list ahents if not editing
-    if (!ubRouting::checkGet(array('edit'), false) AND ( !ubRouting::checkGet('agentstats'))) {
+    if (!ubRouting::checkGet(array('edit'), false) and ( !ubRouting::checkGet('agentstats')) and !ubRouting::checkGet('extinfo')) {
         $statsControl = wf_Link('?module=contrahens&agentstats=true', web_icon_charts());
         show_window(__('Available contrahens') . ' ' . $statsControl, zb_ContrAhentShow());
         show_window(__('Add new'), zb_ContrAhentAddForm());
@@ -73,7 +96,7 @@ if (cfr('AGENTS')) {
 
 
         //list assigns if not editing
-        if ((!ubRouting::checkGet(array('edit'), false)) AND ( !ubRouting::checkGet('agentstats'))) {
+        if ((!ubRouting::checkGet(array('edit'), false)) and ( !ubRouting::checkGet('agentstats')) and !ubRouting::checkGet('extinfo')) {
             show_window(__('Contrahent assign'), web_AgentAssignForm());
             show_window(__('Available assigns'), web_AgentAssignShow());
             show_window(__('Assign overrides'), web_AgentAssignStrictShow());


### PR DESCRIPTION
Module DealWithIt:
    Added new user's status option to terminate misunderstanding of "inactive" and "disconnected" statuses.

Module cess:
    Added ability to store some extended info about contragents. Practically useless thing for 88.88% of users, until certain circumstances...
    
alter.ini:
    New non-mandatory option AGENTS_EXTINFO_ON to enable/disable of storing some extended info about contragents.