### PR TITLE
freezemonth_&_userstats_updates

### DIFF
--- a/api/libs/api.ponboxes.php
+++ b/api/libs/api.ponboxes.php
@@ -77,9 +77,11 @@ class PONBoxes {
                                           'Coupler 45:55' => 'Coupler 45:55',
                                           'Coupler 50:50' => 'Coupler 50:50',
                                           'Splitter 1 x 2' => 'Splitter 1 x 2',
+                                          'Splitter 1 x 3' => 'Splitter 1 x 3',
                                           'Splitter 1 x 4' => 'Splitter 1 x 4',
+                                          'Splitter 1 x 6' => 'Splitter 1 x 6',
                                           'Splitter 1 x 8' => 'Splitter 1 x 8',
-                                          'Splitter 1 x 16' => 'Splitter 1 x 8',
+                                          'Splitter 1 x 16' => 'Splitter 1 x 16',
                                           'Splitter 1 x 32' => 'Splitter 1 x 32',
                                           'Splitter 1 x 64' => 'Splitter 1 x 64'
     );

--- a/api/libs/api.reminder.php
+++ b/api/libs/api.reminder.php
@@ -336,10 +336,7 @@ class Reminder {
                         . $frozenJOIN
                     . $whereString;
 
-
-
             $tmp = simple_queryall($query);
-
 
             if (!empty($tmp)) {
                 $this->AllLogin = $tmp;

--- a/config/alter.ini
+++ b/config/alter.ini
@@ -490,6 +490,10 @@ FRIENDSHIP_CASHTYPEID=1
 FREEZEMONTH_COST=20
 ;Payment type ID for frozen payments
 FREEZEMONTH_CASHTYPE=1
+;Charge freeze payment from users with certain tags only. You may use several tags separated with coma. Optional option.
+;FREEZEMONTH_ONLY_TAG="10,11,42"
+;Charge freeze payment excluding users with certain tags. You may use several tags separated with coma. Optional option.
+;FREEZEMONTH_EXCLUDE_TAG="12,13,44"
 ;Enter tagid for distinguish users in per city actions witch it's colors, comma separated
 ;ALLOWED_COLORS="1,2,3"
 ;Is userside API requests enabled?

--- a/modules/remoteapi/asterisk.php
+++ b/modules/remoteapi/asterisk.php
@@ -266,7 +266,7 @@ if ($_GET['action'] == 'asterisk') {
                                 die(json_encode($contragent));
                             }
 
-                            $userVsrvs = zb_VservicesGetUsersAll($userLogin, true);
+                            $userVsrvs = zb_VservicesGetUsersAll($userLogin, true, true);
                             $userVsrvs = empty($userVsrvs[$userLogin]) ? array() : $userVsrvs[$userLogin];
 
                             if ($apiParam == 'getvservicescount') {
@@ -282,7 +282,14 @@ if ($_GET['action'] == 'asterisk') {
                                 $userSpends[$userData['Tariff']] = array('price' => $userData['Fee'], 'daysperiod' => $userData['period']);
                             }
 
-                            $userSpends = $userSpends + $userVsrvs;
+                            if (!empty($userVsrvs)) {
+                                foreach ($userVsrvs as $eachID => $eachSrv) {
+                                    $vsrvName = $eachSrv['vsrvname'];
+                                    $vsrvTmpArr = array('price' => $eachSrv['price'], 'daysperiod' => $eachSrv['daysperiod']);
+                                    $userSpends[$vsrvName] = $vsrvTmpArr;
+                                }
+                            }
+
                             die(json_encode($userSpends));
 
 

--- a/modules/remoteapi/freezemonth.php
+++ b/modules/remoteapi/freezemonth.php
@@ -3,9 +3,10 @@
 /*
  * Per month freezing fees
  */
-if ($_GET['action'] == 'freezemonth') {
+if (ubRouting::checkGet('action') and ubRouting::get('action') == 'freezemonth') {
+    $processingDebug = (ubRouting::checkGet('param') and ubRouting::get('param') == 'debug2ublog');
     $money = new FundsFlow();
     $money->runDataLoders();
-    $money->makeFreezeMonthFee();
+    $money->makeFreezeMonthFee($processingDebug);
     die('OK:FREEZEMONTH');
 }

--- a/userstats/config/userstats.ini
+++ b/userstats/config/userstats.ini
@@ -149,6 +149,9 @@ ZL_OPTIONS="skins/default/iconz/chrome.png|https://is.gd/wg6BEr|Расширен
 AF_ENABLED=1
 ;each freezing price
 AF_FREEZPRICE=10
+;Just a textual indicator of the period for which freezing fee is charged(e.g. month or day, or whatever)
+;Keep in mind: this will not be localized and will appear "as is"
+;AF_FREEZPRICE_PERIOD="day"
 ;tariffs with enabled freeze - delimiter comma
 AF_TARIFFSALLOWED = Unlim-5
 ;allow freezing for any tariff
@@ -171,16 +174,19 @@ UBA_XML_ADDRESS_STRUCT=0
 
 ; COUNT DAYS ONLINE LEFT:
 ONLINELEFT_COUNT=0
+;Possible values: days, date, mixed
 ONLINELEFT_STYLE="days"
 ONLINELEFT_SPREAD=0
 ONLINELEFT_CREDIT=0
+;Consider all user's virtual services prices when calculating online days left
+;ONLINELEFT_CONSIDER_VSERVICES=0
 
 ; ROUND CASH IN PROFILE:
 ROUND_PROFILE_CASH = 0
 
 ;Public offer mode - contract field will be displayed as "Public offer" with link set as parameter
 ;PUBLIC_OFFER=""
-;Public offer custom link caption. Will not be translated and will appear "as is"
+;Public offer custom link caption. Will not be localized and will appear "as is"
 ;PUBLIC_OFFER_CAPTION=""
 
 ;Document printing support
@@ -220,6 +226,8 @@ PAYMENTS_ENABLED=1
 
 ;Show additional virtual services in user profile?
 VSERVICES_SHOW=0
+;Consider virtual services periods when calculating it's cost?
+;VSERVICES_CONSIDER_PERIODS=0
 
 ;Show traffic stats module?
 TRAFFIC_ENABLED=1

--- a/userstats/languages/russian/lang.php
+++ b/userstats/languages/russian/lang.php
@@ -427,4 +427,9 @@ $lang['def']['ProstoTV'] = 'Просто ТВ';
 $lang['def']['No subscriptions yet'] = 'Еще нету никаких подписок';
 $lang['def']['Playlists'] = 'Плейлисты';
 $lang['def']['Download'] = 'Скачать';
+$lang['def']['year'] = 'год';
+$lang['def']['month'] = 'месяц';
+$lang['def']['day'] = 'день';
+$lang['def']['till the'] = 'до';
+$lang['def']['including additional services'] = 'включая дополнительные услуги';
 ?>

--- a/userstats/languages/ukrainian/lang.php
+++ b/userstats/languages/ukrainian/lang.php
@@ -428,5 +428,9 @@ $lang['def']['ProstoTV'] = 'Просто ТВ';
 $lang['def']['No subscriptions yet'] = 'Наразі немає передплат';
 $lang['def']['Playlists'] = 'Плейлисти';
 $lang['def']['Download'] = 'Завантажити';
-
+$lang['def']['year'] = 'рік';
+$lang['def']['month'] = 'місяць';
+$lang['def']['day'] = 'день';
+$lang['def']['till the'] = 'до';
+$lang['def']['including additional services'] = 'включаючи додаткові послуги';
 ?>

--- a/userstats/modules/general/zfreeze/index.php
+++ b/userstats/modules/general/zfreeze/index.php
@@ -9,6 +9,7 @@ $FreezingAvailable = true;
 if ($us_config['AF_ENABLED']) {
     // freeze options
     $freezeprice = $us_config['AF_FREEZPRICE'];
+    $freezepriceperiod = (empty($us_config['AF_FREEZPRICE_PERIOD'])) ? '' : $us_config['AF_FREEZPRICE_PERIOD'];
     $allowed_tariffs_raw = $us_config['AF_TARIFFSALLOWED'];
     $allowed_tariffs = explode(',', $allowed_tariffs_raw);
     $allowed_any_tariff = (isset($us_config['AF_TARIFF_ALLOW_ANY'])) ? $us_config['AF_TARIFF_ALLOW_ANY'] : 0;
@@ -100,8 +101,8 @@ if ($us_config['AF_ENABLED']) {
 
                     //show some forms and notices
                     $af_message = __('Service "account freeze" will allow you to suspend the charge of the monthly fee during your long absence - such as holidays or vacations. The cost of this service is:') . ' ';
-                    $af_message.=la_tag('b') . $freezeprice . ' ' . $af_currency . la_tag('b', true) . '. ';
-                    $af_message.=__('Be aware that access to the network will be limited to immediately after you confirm your desire to freeze the account. To unfreeze the account you need to contact the nearest office.');
+                    $af_message.= la_tag('b') . $freezeprice . ' ' . $af_currency . ' ' . $freezepriceperiod . la_tag('b', true) . '. ';
+                    $af_message.= __('Be aware that access to the network will be limited to immediately after you confirm your desire to freeze the account. To unfreeze the account you need to contact the nearest office.');
                     // terms of service
                     show_window(__('Account freezing'), $af_message . $inputs);
 


### PR DESCRIPTION
api.usertags:
    Added ability to get virtual services with identical names and IDs separately, keeping some kind of uniqueness. Implementation may look a little bit shitty, but it is just as it is. 
    zb_VservicesGetUsersAll() function refactored, keeping backwards compatibility. 
   
   
Freeze month fee:
    Slightly refactored.
    Added ability to charge fee only from users with certain tags assigned. Controlled by FREEZEMONTH_ONLY_TAG alter.ini option.
    Added ability to exclude users with certain tags assigned from fee charge. Controlled by FREEZEMONTH_EXCLUDE_TAG alter.ini option.
    Added debug to weblog ability.
   
Userstats:
    Added ability to show unique virtual services with identical names and IDs separately.
    Added ability to consider virtual services cost while calculating online days left and show the virtual services cost to user  
    ONLINELEFT_STYLE userstats.ini option now accepts "mixed" value which leads to showing "online days left" and "online left till" simultaneously  
    Added ability to show freezing fee charge period. Just as a textual label with no localizations applied.   
    Added some translations