### PR TITLE
added correct HTTP Status code for unauthorized response

### DIFF
--- a/userstats/modules/engine/api.userstats.php
+++ b/userstats/modules/engine/api.userstats.php
@@ -41,6 +41,7 @@ function zbs_UserDetectIp($debug = false) {
         if (!empty($ip)) {
             return($ip);
         } else {
+            http_response_code(401);
             die('ERROR_WRONG_UBERAUTH');
         }
     }


### PR DESCRIPTION
## Description
_Added a corresponding status code with response when the login fails due to wrong credentials. Main purpose is to improve compatibility and make exception handling easier when working with API._

