### PR TITLE
Added 'tariffAlias' field and made $paymentId of static type

### DIFF
--- a/userstats/modules/engine/api.userstats.php
+++ b/userstats/modules/engine/api.userstats.php
@@ -1000,7 +1000,7 @@ function zbs_UserShowXmlAgentData($login) {
     $reqResult[] = array('email' => $email);
     $reqResult[] = array('credit' => @$userdata['Credit']);
     $reqResult[] = array('creditexpire' => $credexpire);
-    $reqResult[] = array('payid' => $paymentid);
+    $reqResult[] = array('payid' => strval($paymentid));
     $reqResult[] = array('contract' => $contract);
     $reqResult[] = array('tariff' => $userdata['Tariff']);
     $reqResult[] = array('tariffnm' => $tariffNm);

--- a/userstats/modules/engine/api.userstats.php
+++ b/userstats/modules/engine/api.userstats.php
@@ -1003,6 +1003,7 @@ function zbs_UserShowXmlAgentData($login) {
     $reqResult[] = array('payid' => strval($paymentid));
     $reqResult[] = array('contract' => $contract);
     $reqResult[] = array('tariff' => $userdata['Tariff']);
+    $reqResult[] = array('tariffAlias' => __($userdata['Tariff']));
     $reqResult[] = array('tariffnm' => $tariffNm);
     $reqResult[] = array('traffdownload' => zbs_convert_size($traffdown));
     $reqResult[] = array('traffupload' => zbs_convert_size($traffup));


### PR DESCRIPTION
$paymentId variable is dynamically typed (in some cases it returns Int and in other it returns String) which is tricky to handle from an API standpoint. Making this String by default resolves this issue.

'tariffAlias' field will return an optional translation of tariff that can be added in "languages" folder