### PR TITLE
opayz_sms_notify

### DIFF
--- a/api/libs/api.usms.php
+++ b/api/libs/api.usms.php
@@ -89,7 +89,7 @@ class UbillingSMS {
      */
     public function setDirection($queueFile, $keyType, $entity, $forceDirection = '') {
         if ($this->smsRoutingFlag) {
-            if (file_exists(self::QUEUE_PATH . $queueFile)) {
+            if (!empty($queueFile) and file_exists(self::QUEUE_PATH . $queueFile)) {
                 if (empty($forceDirection)) {
                     $newDirection = $this->smsDirections->getDirection($keyType, $entity);
                 } else {
@@ -157,7 +157,6 @@ class UbillingSMS {
         }
         return ($result);
     }
-
 }
 
 ?>

--- a/api/libs/api.workaround.php
+++ b/api/libs/api.workaround.php
@@ -6679,6 +6679,27 @@ function zb_split_mb($string, $length = 1) {
 }
 
 /**
+ * Tries to re-format incorrectly inputted cell number to bring it to the correct form
+ *
+ * @param $number
+ *
+ * @return bool|mixed|string
+ */
+function zb_CleanMobileNumber($number) {
+    if (!empty($number)) {
+        global $ubillingConfig;
+        $prefix = $ubillingConfig->getAlterParam('REMINDER_PREFIX', '');
+
+        $number = trim($number);
+        $number = ubRouting::filters($number, 'int');
+        $number = SendDog::cutInternationalsFromPhoneNum($number);
+        $number = $prefix . $number;
+    }
+
+    return ($number);
+}
+
+/**
  * Returns list of available free Juniper NASes
  * 
  * @return string

--- a/api/libs/api.workaround.php
+++ b/api/libs/api.workaround.php
@@ -6686,7 +6686,7 @@ function zb_split_mb($string, $length = 1) {
  * @return bool|mixed|string
  */
 function zb_CleanMobileNumber($number) {
-    if (!empty($number)) {
+    if (!empty($number) and substr(trim($number), 0, 1) != '+') {
         global $ubillingConfig;
         $prefix = $ubillingConfig->getAlterParam('REMINDER_PREFIX', '');
 

--- a/config/alter.ini
+++ b/config/alter.ini
@@ -1305,16 +1305,16 @@ USERALLDATA_CACHETIME=1440
 ;Use cached data for rendering some user lists. Enabling this significantly improves performance.
 USERLISTS_USE_CACHE=1
 ;Are OpenPayz SMS notifications enabled?
-OP_SMS_NOTIFY_ENABLED=0
+;OP_SMS_NOTIFY_ENABLED=0
 ;Interval in minutes to pull payments from payments log
 ;Should be grater then the "opayzsmsnotify" RemoteAPI frequency call, otherwise it will end up with un-notified payments:
 ;like if you call RemoteAPI "opayzsmsnotify" every 10 minutes this parameter should be >= 11
-OP_SMS_NOTIFY_PAYMENTS_PULL_INTERVAL=5
+;OP_SMS_NOTIFY_PAYMENTS_PULL_INTERVAL=5
 ;Enables usage of ALL associated with user mobile numbers
-OP_SMS_NOTIFY_USE_EXTMOBILES=0
+;OP_SMS_NOTIFY_USE_EXTMOBILES=0
 ;Force translit for OpenPayz SMS notifications
-OP_SMS_NOTIFY_FORCED_TRANSLIT=0
+;OP_SMS_NOTIFY_FORCED_TRANSLIT=0
 ;Enables debug mode for OpenPayz SMS notifications with verbose logging
-OP_SMS_NOTIFY_DEBUG_ON=0
+;OP_SMS_NOTIFY_DEBUG_ON=0
 ;OpenPayz SMS notifications text. Supports {ROUNDPAYMENTAMOUNT} and {ROUNDBALANCE} macro.
-OP_SMS_NOTIFY_TEXT="Vash rakhunok popovneno na {ROUNDPAYMENTAMOUNT} grn. Zalyshok na vashomu rahunku skladae {ROUNDBALANCE} grn. Dyakuemo za te, scho vy z namy."
+;OP_SMS_NOTIFY_TEXT="Vash rakhunok popovneno na {ROUNDPAYMENTAMOUNT} grn. Zalyshok na vashomu rahunku skladae {ROUNDBALANCE} grn. Dyakuemo za te, scho vy z namy."

--- a/config/alter.ini
+++ b/config/alter.ini
@@ -1308,8 +1308,8 @@ USERLISTS_USE_CACHE=1
 OP_SMS_NOTIFY_ENABLED=0
 ;Interval in minutes to pull payments from payments log
 ;Should be grater then the "opayzsmsnotify" RemoteAPI frequency call, otherwise it will end up with un-notified payments:
-;like if you call "opayzsmsnotify" every 10 minutes this parameter should be >= 11
-OP_SMS_NOTIFY_PAYMENTS_PULL_INTERVAL=10
+;like if you call RemoteAPI "opayzsmsnotify" every 10 minutes this parameter should be >= 11
+OP_SMS_NOTIFY_PAYMENTS_PULL_INTERVAL=5
 ;Enables usage of ALL associated with user mobile numbers
 OP_SMS_NOTIFY_USE_EXTMOBILES=0
 ;Force translit for OpenPayz SMS notifications
@@ -1317,4 +1317,4 @@ OP_SMS_NOTIFY_FORCED_TRANSLIT=0
 ;Enables debug mode for OpenPayz SMS notifications with verbose logging
 OP_SMS_NOTIFY_DEBUG_ON=0
 ;OpenPayz SMS notifications text. Supports {ROUNDPAYMENTAMOUNT} and {ROUNDBALANCE} macro.
-OP_SMS_NOTIFY_TEXT="Vash rakhunok popovneno na {ROUNDPAYMENTAMOUNT} grn. Vash potochny balans {ROUNDBALANCE} grn. Dyakuemo za te, scho vy z namy."
+OP_SMS_NOTIFY_TEXT="Vash rakhunok popovneno na {ROUNDPAYMENTAMOUNT} grn. Zalyshok na vashomu rahunku skladae {ROUNDBALANCE} grn. Dyakuemo za te, scho vy z namy."

--- a/config/alter.ini
+++ b/config/alter.ini
@@ -1299,8 +1299,22 @@ AERIAL_ALERTS_NOTIFY=""
 DHCP_ENABLED=1
 ;Lists of mountpoints to control capacity in system health report. Comma - separator. Optional option.
 SYSLOAD_DISKS=""
-;Sets all user data caching timeout in minutes. Reducing it may cause whole system performance issues. 
+;Sets all user data caching timeout in minutes. Reducing it may cause whole system performance issues.
 ;Default value: 1440. Do not modify this option without fully understanding what is happening. Optional option.
 USERALLDATA_CACHETIME=1440
 ;Use cached data for rendering some user lists. Enabling this significantly improves performance.
 USERLISTS_USE_CACHE=1
+;Are OpenPayz SMS notifications enabled?
+OP_SMS_NOTIFY_ENABLED=0
+;Interval in minutes to pull payments from payments log
+;Should be grater then the "opayzsmsnotify" RemoteAPI frequency call, otherwise it will end up with un-notified payments:
+;like if you call "opayzsmsnotify" every 10 minutes this parameter should be >= 11
+OP_SMS_NOTIFY_PAYMENTS_PULL_INTERVAL=10
+;Enables usage of ALL associated with user mobile numbers
+OP_SMS_NOTIFY_USE_EXTMOBILES=0
+;Force translit for OpenPayz SMS notifications
+OP_SMS_NOTIFY_FORCED_TRANSLIT=0
+;Enables debug mode for OpenPayz SMS notifications with verbose logging
+OP_SMS_NOTIFY_DEBUG_ON=0
+;OpenPayz SMS notifications text. Supports {ROUNDPAYMENTAMOUNT} and {ROUNDBALANCE} macro.
+OP_SMS_NOTIFY_TEXT="Vash rakhunok popovneno na {ROUNDPAYMENTAMOUNT} grn. Vash potochny balans {ROUNDBALANCE} grn. Dyakuemo za te, scho vy z namy."

--- a/content/updates/sql/1.2.7.sql
+++ b/content/updates/sql/1.2.7.sql
@@ -8,3 +8,18 @@ CREATE TABLE IF NOT EXISTS `olt_qinq` (
   KEY `svlan_id` (`svlan_id`),
   KEY `cvlan` (`cvlan`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;
+
+CREATE TABLE IF NOT EXISTS `op_sms_notifications` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `payment_id` int(11) NOT NULL,
+  `date` datetime NOT NULL,
+  `login` varchar(255) NOT NULL,
+  `balance` double NOT NULL DEFAULT 0,
+  `summ` double NOT NULL DEFAULT 0,
+  `processed` tinyint(1) UNSIGNED DEFAULT 0,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `payment_id` (`payment_id`),
+  KEY `login` (`login`),
+  KEY `date` (`date`),
+  KEY `summ` (`summ`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;

--- a/docs/test_dump.sql
+++ b/docs/test_dump.sql
@@ -3154,3 +3154,19 @@ CREATE TABLE IF NOT EXISTS `olt_qinq` (
   KEY `svlan_id` (`svlan_id`),
   KEY `cvlan` (`cvlan`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;
+
+
+CREATE TABLE IF NOT EXISTS `op_sms_notifications` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `payment_id` int(11) NOT NULL,
+  `date` datetime NOT NULL,
+  `login` varchar(255) NOT NULL,
+  `balance` double NOT NULL DEFAULT 0,
+  `summ` double NOT NULL DEFAULT 0,
+  `processed` tinyint(1) UNSIGNED DEFAULT 0,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `payment_id` (`payment_id`),
+  KEY `login` (`login`),
+  KEY `date` (`date`),
+  KEY `summ` (`summ`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;

--- a/modules/remoteapi/opayzsmsnotify.php
+++ b/modules/remoteapi/opayzsmsnotify.php
@@ -5,9 +5,15 @@ if (ubRouting::get('action') == 'opazysmsnotify') {
 
     if ($ubillingConfig->getAlterParam('OP_SMS_NOTIFY_ENABLED')) {
         if ($ubillingConfig->getAlterParam('SENDDOG_ENABLED')) {
-            $OpenPayz = new OpenPayz();
-            $OpenPayz->pullNotysPayments();
-            $OpenPayz->processNotys();
+            $openpayz = new OpenPayz();
+            $openpayz->pullNotysPayments();
+            $openpayz->processNotys();
+
+            die('OPAZYSMSNOTIFY: FINISHED PROCESSING');
+        } else {
+            die('OPAZYSMSNOTIFY ERROR: SENDDOG IS DISABLED');
         }
+    } else {
+        die('OPAZYSMSNOTIFY ERROR: OPENPAZY SMS NOTIFICATION IS DISABLED');
     }
 }

--- a/modules/remoteapi/opayzsmsnotify.php
+++ b/modules/remoteapi/opayzsmsnotify.php
@@ -1,0 +1,13 @@
+<?php
+
+if (ubRouting::get('action') == 'opazysmsnotify') {
+    global $ubillingConfig;
+
+    if ($ubillingConfig->getAlterParam('OP_SMS_NOTIFY_ENABLED')) {
+        if ($ubillingConfig->getAlterParam('SENDDOG_ENABLED')) {
+            $OpenPayz = new OpenPayz();
+            $OpenPayz->pullNotysPayments();
+            $OpenPayz->processNotys();
+        }
+    }
+}


### PR DESCRIPTION
OpenPayz SMS notifications: 
    updated and tested
    
USMS:
    some fix with queue file existence check
    
RemoteAPI:
    added new call "opayzsmsnotify"
    
alter.ini:
    New non-mandatory options:    
    OP_SMS_NOTIFY_ENABLED - controls the OpenPayz SMS notifications ON/OFF state    
    OP_SMS_NOTIFY_PAYMENTS_PULL_INTERVAL - sets interval in minutes to pull payments from payments log    
    OP_SMS_NOTIFY_USE_EXTMOBILES - controls the usage of ALL associated with user mobile numbers aka "extmobiles"    
    OP_SMS_NOTIFY_FORCED_TRANSLIT - forces translit for OpenPayz SMS notifications    
    OP_SMS_NOTIFY_DEBUG_ON - enables debug mode for OpenPayz SMS notifications with verbose logging
    OP_SMS_NOTIFY_TEXT - OpenPayz SMS notifications text. Supports {ROUNDPAYMENTAMOUNT} and {ROUNDBALANCE} macro.