### PR TITLE
Fix logic for module realipcontrol

### DIFF
--- a/modules/general/realipcontrol/index.php
+++ b/modules/general/realipcontrol/index.php
@@ -171,7 +171,7 @@ if (cfr('REALIPCONTROL')) {
                                 $tariffPrice = $this->allTrariffPrices[$userTariff];
                                 //Tariff isnt free
                                 if ($tariffPrice > 0) {
-                                    $maxDebt = '-' . ($this->debtLimit * $tariffPrice);
+                                    $maxDebt = ($this->debtLimit * $tariffPrice);
                                     $curMoneyLimit = $each['Cash'] + $each['Credit'];
                                     if ($curMoneyLimit <= $maxDebt) {
                                         if ($each['U0'] == 0) {


### PR DESCRIPTION
## Я хер его знает у кого оно вообще работало
Еще логика нихрена не работает для посуточных тарифов
![image](https://user-images.githubusercontent.com/11805503/167491193-5547c18d-af43-42b7-b873-43f9db280c55.png)
```
$tariffPrice = 7;
$debtLimit = 3;
$Cash = 20;
$Credit = 1;
$Login = "NEED TAKE";
if ($tariffPrice > 0) {
    $maxDebt = ($debtLimit * $tariffPrice);
    $curMoneyLimit = $Cash + $Credit;
    echo 'maxDebt: ' . $maxDebt . PHP_EOL;
    echo 'curMoneyLimit: ' . $curMoneyLimit . PHP_EOL;
    if ($curMoneyLimit <= "-" . $maxDebt) {
        echo 'ORIGINAL: ' . $curMoneyLimit . '< ' . $maxDebt . PHP_EOL;
        echo $Login .  PHP_EOL;
    }
    if ($curMoneyLimit <= $maxDebt) {
        echo 'PR: ' . $curMoneyLimit . '< ' . $maxDebt . PHP_EOL;
        echo $Login .  PHP_EOL;
    }
}
```