### PR TITLE
opayz_sms_notify_update

### DIFF
--- a/config/alter.ini
+++ b/config/alter.ini
@@ -1320,3 +1320,5 @@ USERLISTS_USE_CACHE=1
 ;OP_SMS_NOTIFY_DEBUG_ON=0
 ;OpenPayz SMS notifications text. Supports {ROUNDPAYMENTAMOUNT} and {ROUNDBALANCE} macro.
 ;OP_SMS_NOTIFY_TEXT="Vash rakhunok popovneno na {ROUNDPAYMENTAMOUNT} grn. Zalyshok na vashomu rahunku skladae {ROUNDBALANCE} grn. Dyakuemo za te, scho vy z namy."
+;Send only for those users, who has REMINDER_TAGID assigned
+;OP_SMS_NOTIFY_RESPECT_REMINDER_TAGID=0


### PR DESCRIPTION
OpenPayz SMS notifications can respect REMINDER_TAGID from now on

alter.ini
    New non-mandatory option OP_SMS_NOTIFY_RESPECT_REMINDER_TAGID - which controls sending only for those users, who has REMINDER_TAGID assigned