### PR TITLE
ponizer_serial_char_case_control

### DIFF
--- a/api/libs/api.ponbdcomgp.php
+++ b/api/libs/api.ponbdcomgp.php
@@ -16,6 +16,8 @@ class PONBdcomGP extends PONBdcom {
         $oltIp = $this->oltParameters['IP'];
         $oltCommunity = $this->oltParameters['COMMUNITY'];
         $oltNoFDBQ = $this->oltParameters['NOFDB'];
+        $this->onuSerialCaseMode = (isset($this->snmpTemplates[$oltModelId]['misc']['SERIAL_CASE_MODE'])
+                                    ? $this->snmpTemplates[$oltModelId]['misc']['SERIAL_CASE_MODE'] : 1);
 
         $sigIndexOID = $this->snmpTemplates[$oltModelId]['signal']['SIGINDEX'];
         $sigIndex = $this->snmp->walk($oltIp . ':' . self::SNMPPORT, $oltCommunity, $sigIndexOID, self::SNMPCACHE);
@@ -79,7 +81,7 @@ class PONBdcomGP extends PONBdcom {
         $macIndex = str_replace('"', '', $macIndex);
         $macIndex = explodeRows($macIndex);
 
-        $this->signalParse($oltid, $sigIndex, $macIndex, $this->snmpTemplates[$oltModelId]['signal']);
+        $this->signalParse($oltid, $sigIndex, $macIndex, $this->snmpTemplates[$oltModelId]['signal'], $serialCaseMode);
 //This is here because BDCOM is BDCOM and another snmp queries cant be processed after MACINDEX query in some cases.
         if (isset($this->snmpTemplates[$oltModelId]['misc'])) {
             if (isset($this->snmpTemplates[$oltModelId]['misc']['DISTINDEX'])) {

--- a/api/libs/api.pongcomgl5610.php
+++ b/api/libs/api.pongcomgl5610.php
@@ -18,6 +18,8 @@ class PONGCOMGL5610 extends PONProto {
         $oltNoFDBQ = $this->oltParameters['NOFDB'];
         $oltIPPORT = $oltIp . ':' . self::SNMPPORT;
         $chassisIndexToRemove = '0.';    // this needed because with chassis index included - OIDs are not processable
+        $this->onuSerialCaseMode = (isset($this->snmpTemplates[$oltModelId]['onu']['SERIAL_CASE_MODE'])
+                                    ? $this->snmpTemplates[$oltModelId]['onu']['SERIAL_CASE_MODE'] : 0);
 
         $sigIndex = $this->walkCleared($oltIPPORT, $oltCommunity,
                                        $this->snmpTemplates[$oltModelId]['signal']['SIGINDEX'],
@@ -140,6 +142,12 @@ class PONGCOMGL5610 extends PONProto {
                 $tmpONUPortLLID = trim($line[0]);
 //                $tmpONUMAC = strtolower(AddMacSeparator(RemoveMacAddressSeparator(trim($line[1]), array(':', '-', '.', ' '))));     //mac address
                 $tmpONUMAC = trim($line[1]);
+
+                if ($this->onuSerialCaseMode == 1) {
+                    $tmpONUMAC = strtolower($tmpONUMAC);
+                } elseif ($this->onuSerialCaseMode == 2) {
+                    $tmpONUMAC = strtoupper($tmpONUMAC);
+                }
 
 
 //mac is present

--- a/api/libs/api.ponizer.php
+++ b/api/libs/api.ponizer.php
@@ -328,6 +328,16 @@ class PONizer {
     protected $onuUniStatusEnabled = false;
 
     /**
+     * Placeholder for PON_ONU_SERIAL_CASE_MODE alter.ini option
+     *  0 - no case convert
+     *  1 - lowercase
+     *  2 - uppercase
+     *
+     * @var bool
+     */
+    protected $onuSerialCaseMode = 0;
+
+    /**
      * Contains all busy ONU MAC/serials as lowercase onuIdent=>onuId
      *
      * @var array
@@ -494,6 +504,7 @@ class PONizer {
         $this->ipColumnVisible = ($this->ubConfig->getAlterParam('PONIZER_NO_IP_COLUMN')) ? false : true;
         $this->llidColVisibleUnknownONU = $this->ubConfig->getAlterParam('PON_UKNKOWN_ONU_LLID_SHOW', false);
         $this->onuUniStatusEnabled = $this->ubConfig->getAlterParam('PON_ONU_UNI_STATUS_ENABLED', false);
+        $this->onuSerialCaseMode = $this->ubConfig->getAlterParam('PON_ONU_SERIAL_CASE_MODE', 0);
 
         if ($this->ponIfDescribe) {
             $this->ponInterfaces = new PONIfDesc();
@@ -1501,6 +1512,13 @@ class PONizer {
         $oltid = ubRouting::filters($oltid, 'int');
         $ip = ubRouting::filters($ip, 'mres');
         $serial = ubRouting::filters($serial, 'mres');
+
+        if ($this->onuSerialCaseMode == 1) {
+            $serial = strtolower($serial);
+        } elseif ($this->onuSerialCaseMode == 2) {
+            $serial = strtoupper($serial);
+        }
+
         $login = trim($login);
         $login = ubRouting::filters($login, 'mres');
 

--- a/api/libs/api.ponproto.php
+++ b/api/libs/api.ponproto.php
@@ -27,6 +27,19 @@ class PONProto {
     protected $onuOfflineSignalLevel = '-9000';
 
     /**
+     * Placeholder for SERIAL_CASE_MODE SNMP template option
+     *  0 - no case convert
+     *  1 - lowercase
+     *  2 - uppercase
+     *
+     * As far as MAC and Serial are interchangeable during polling for a historical reason
+     * - we should keep "1" as a default value.
+     *
+     * @var bool
+     */
+    protected $onuSerialCaseMode = 1;
+
+    /**
      * SNMPHelper object instance
      *
      * @var object
@@ -172,7 +185,13 @@ class PONProto {
                     $macRaw = trim($line[1]); //mac address
                     $devIndex = trim($line[0]); //device index
                     $macRaw = str_replace(' ', ':', $macRaw);
-                    $macRaw = strtolower($macRaw);
+
+                    if ($this->onuSerialCaseMode == 1) {
+                        $macRaw = strtolower($macRaw);
+                    } elseif ($this->onuSerialCaseMode == 2) {
+                        $macRaw = strtoupper($macRaw);
+                    }
+
                     $macTmp[$devIndex] = $macRaw;
                 }
             }
@@ -239,7 +258,13 @@ class PONProto {
                     $macRaw = trim($line[1]); //mac address
                     $devIndex = trim($line[0]); //device index
                     $macRaw = str_replace(' ', ':', $macRaw);
-                    $macRaw = strtolower($macRaw);
+
+                    if ($this->onuSerialCaseMode == 1) {
+                        $macRaw = strtolower($macRaw);
+                    } elseif ($this->onuSerialCaseMode == 2) {
+                        $macRaw = strtoupper($macRaw);
+                    }
+
                     $onuTmp[$devIndex] = $macRaw;
                 }
             }

--- a/config/alter.ini
+++ b/config/alter.ini
@@ -1382,3 +1382,10 @@ MULTI_ENVY_PROC=0
 ;DDT_ENDPREVDAYS=10
 ;Is corp user selector searchable?
 CORPSEL_SEARCHBL=0
+;Controls storing of the GPON ONU serials in a specified case upon ONU creation.
+;Does not affect custom PON implementations, like PONZTE, PONHUAWEI and so on.
+;Does not affect storing of the MAC/Serial data gathered during SNMP polling.
+;   0 - no case convert
+;   1 - lowercase
+;   2 - uppercase
+;PON_ONU_SERIAL_CASE_MODE=0

--- a/config/snmptemplates/BDCOM_GP3608
+++ b/config/snmptemplates/BDCOM_GP3608
@@ -25,6 +25,11 @@ INTERFACEINDEX=".1.3.6.1.2.1.2.2.1.2"
 INTERFACEVALUE="STRING:"
 RTTINDEX=".1.3.6.1.4.1.3320.101.11.1.1.8"
 ONU_RENDER_MODE="serial"
+;Case of the serial number characters:
+;   0 - no case convert
+;   1 - lowercase
+;   2 - uppercase
+SERIAL_CASE_MODE="1"
 
 [system]
 CPULOAD=".1.3.6.1.2.1.25.3.3.1.2"

--- a/config/snmptemplates/GCOM_GL5610_GPON
+++ b/config/snmptemplates/GCOM_GL5610_GPON
@@ -34,6 +34,11 @@ DESCRONUINDEX=".1.3.6.1.4.1.13464.1.11.4.1.1.25.0"
 ;DESCRCOMMIT=".1.3.6.1.4.1.37950.1.1.5.12.1.16.4.0"
 ;DESCRIPTIONGET=".1.3.6.1.4.1.37950.1.1.5.12.1.25.1.9"
 ;DESCRVALUE="STRING:"
+;Case of the serial number characters:
+;   0 - no case convert
+;   1 - lowercase
+;   2 - uppercase
+SERIAL_CASE_MODE="0"
 
 ;.1.3.6.1.4.1.13464.1.2.4.1.2.1.1.1 - MAC VLAN
 ;.1.3.6.1.4.1.13464.1.2.4.1.2.1.1.2 - VLAN


### PR DESCRIPTION
PONizer:
    Added ability to control the case of the ONU serial number via the alter.ini option and similar SNMP template option.
    The idea:
    The alter.ini option is solely responsible for setting the serial number case on the frontend - that is, all sorts of ONU registrations by humans.
    On the other hand - options in the SNMP templates are responsible for setting the serial number case at the time of the devices(OLTs) SNMP polling.
    The supposed result - is that we can clearly establish the uniformity of the ONU serial number case in the database for the registered ONU, as well as in the SNMP polling cache files.

alter.ini:
    Added new non-mandatory option PON_ONU_SERIAL_CASE_MODE which controls storing of the GPON ONU serials in a specified case upon ONU creation.