### PR TITLE
ubrouting_checkGet_Post_update

### DIFF
--- a/api/libs/api.ubrouting.php
+++ b/api/libs/api.ubrouting.php
@@ -28,26 +28,50 @@ class ubRouting {
      * 
      * @param array/string $params array of variable names to check or single variable name as string
      * @param bool  $ignoreEmpty ignore or not existing variables with empty values (like wf_Check)
+     * @param bool $atleastOneExists returns "true" when encounters the very first existent GET param. Respects the $ignoreEmpty parameter.
      * 
      * @return bool
      */
-    public static function checkGet($params, $ignoreEmpty = true) {
+    public static function checkGet($params, $ignoreEmpty = true, $atleastOneExists = false) {
         if (!empty($params)) {
             if (!is_array($params)) {
                 //single param check
                 $params = array($params);
             }
+
             foreach ($params as $eachparam) {
                 if (!isset($_GET[$eachparam])) {
-                    return (false);
+                    if ($atleastOneExists) {
+                        // traversing through the array till existent GET param found or the end of the array
+                        continue;
+                    } else {
+                        return (false);
+                    }
+                } elseif ($atleastOneExists and !$ignoreEmpty) {
+                    return (true);
                 }
+
                 if ($ignoreEmpty) {
                     if (empty($_GET[$eachparam])) {
-                        return (false);
+                        if ($atleastOneExists) {
+                            // traversing through the array till existent and non-empty GET param found or the end of the array
+                            continue;
+                        } else {
+                            return (false);
+                        }
+                    } elseif ($atleastOneExists) {
+                        return (true);
                     }
                 }
             }
-            return(true);
+
+            if ($atleastOneExists) {
+                // if "$atleastOneExists = true" and we got here - none of the GET parameters were existent or non-empty then,
+                // and we failed to find at least one
+                return (false);
+            } else {
+                return (true);
+            }
         } else {
             throw new Exception('EX_PARAMS_EMPTY');
         }
@@ -55,29 +79,53 @@ class ubRouting {
 
     /**
      * Checks is all of variables array present in POST scope
-     * 
+     *
      * @param array/string $params array of variable names to check or single variable name as string
      * @param bool  $ignoreEmpty ignore or not existing variables with empty values (like wf_Check)
-     * 
+     * @param bool $atleastOneExists returns "true" when encounters the very first existent GET param. Respects the $ignoreEmpty parameter.
+     *
      * @return bool
      */
-    public static function checkPost($params, $ignoreEmpty = true) {
+    public static function checkPost($params, $ignoreEmpty = true, $atleastOneExists = false) {
         if (!empty($params)) {
             if (!is_array($params)) {
                 //single param check
                 $params = array($params);
             }
+
             foreach ($params as $eachparam) {
                 if (!isset($_POST[$eachparam])) {
-                    return (false);
+                    if ($atleastOneExists) {
+                        // traversing through the array till existent POST param found or the end of the array
+                        continue;
+                    } else {
+                        return (false);
+                    }
+                } elseif ($atleastOneExists and !$ignoreEmpty) {
+                    return (true);
                 }
+
                 if ($ignoreEmpty) {
                     if (empty($_POST[$eachparam])) {
-                        return (false);
+                        if ($atleastOneExists) {
+                            // traversing through the array till existent and non-empty POST param found or the end of the array
+                            continue;
+                        } else {
+                            return (false);
+                        }
+                    } elseif ($atleastOneExists) {
+                        return (true);
                     }
                 }
             }
-            return (true);
+
+            if ($atleastOneExists) {
+                // if "$atleastOneExists = true" and we got here - none of the POST parameters were existent or non-empty then,
+                // and we failed to find at least one
+                return (false);
+            } else {
+                return (true);
+            }
         } else {
             throw new Exception('EX_PARAMS_EMPTY');
         }

--- a/userstats/modules/engine/api.ubrouting.php
+++ b/userstats/modules/engine/api.ubrouting.php
@@ -28,26 +28,50 @@ class ubRouting {
      * 
      * @param array/string $params array of variable names to check or single variable name as string
      * @param bool  $ignoreEmpty ignore or not existing variables with empty values (like wf_Check)
-     * 
+     * @param bool $atleastOneExists returns "true" when encounters the very first existent GET param. Respects the $ignoreEmpty parameter.
+     *
      * @return bool
      */
-    public static function checkGet($params, $ignoreEmpty = true) {
+    public static function checkGet($params, $ignoreEmpty = true, $atleastOneExists = false) {
         if (!empty($params)) {
             if (!is_array($params)) {
                 //single param check
                 $params = array($params);
             }
+
             foreach ($params as $eachparam) {
                 if (!isset($_GET[$eachparam])) {
-                    return (false);
+                    if ($atleastOneExists) {
+                        // traversing through the array till existent GET param found or the end of the array
+                        continue;
+                    } else {
+                        return (false);
+                    }
+                } elseif ($atleastOneExists and !$ignoreEmpty) {
+                    return (true);
                 }
+
                 if ($ignoreEmpty) {
                     if (empty($_GET[$eachparam])) {
-                        return (false);
+                        if ($atleastOneExists) {
+                            // traversing through the array till existent and non-empty GET param found or the end of the array
+                            continue;
+                        } else {
+                            return (false);
+                        }
+                    } elseif ($atleastOneExists) {
+                        return (true);
                     }
                 }
             }
-            return(true);
+
+            if ($atleastOneExists) {
+                // if "$atleastOneExists = true" and we got here - none of the GET parameters were existent or non-empty then,
+                // and we failed to find at least one
+                return (false);
+            } else {
+                return (true);
+            }
         } else {
             throw new Exception('EX_PARAMS_EMPTY');
         }
@@ -58,26 +82,50 @@ class ubRouting {
      * 
      * @param array/string $params array of variable names to check or single variable name as string
      * @param bool  $ignoreEmpty ignore or not existing variables with empty values (like wf_Check)
+     * @param bool $atleastOneExists returns "true" when encounters the very first existent GET param. Respects the $ignoreEmpty parameter.
      * 
      * @return bool
      */
-    public static function checkPost($params, $ignoreEmpty = true) {
+    public static function checkPost($params, $ignoreEmpty = true, $atleastOneExists = false) {
         if (!empty($params)) {
             if (!is_array($params)) {
                 //single param check
                 $params = array($params);
             }
+
             foreach ($params as $eachparam) {
                 if (!isset($_POST[$eachparam])) {
-                    return (false);
+                    if ($atleastOneExists) {
+                        // traversing through the array till existent POST param found or the end of the array
+                        continue;
+                    } else {
+                        return (false);
+                    }
+                } elseif ($atleastOneExists and !$ignoreEmpty) {
+                    return (true);
                 }
+
                 if ($ignoreEmpty) {
                     if (empty($_POST[$eachparam])) {
-                        return (false);
+                        if ($atleastOneExists) {
+                            // traversing through the array till existent and non-empty POST param found or the end of the array
+                            continue;
+                        } else {
+                            return (false);
+                        }
+                    } elseif ($atleastOneExists) {
+                        return (true);
                     }
                 }
             }
-            return (true);
+
+            if ($atleastOneExists) {
+                // if "$atleastOneExists = true" and we got here - none of the POST parameters were existent or non-empty then,
+                // and we failed to find at least one
+                return (false);
+            } else {
+                return (true);
+            }
         } else {
             throw new Exception('EX_PARAMS_EMPTY');
         }

--- a/userstats/modules/engine/api.xmlagent.php
+++ b/userstats/modules/engine/api.xmlagent.php
@@ -171,15 +171,18 @@ class XMLAgent {
         $messages       = false;
         $restapiMethod  = '';
         $debugData      = '';
-        $getUserData    = !(ubRouting::checkGet('payments')
-                            or ubRouting::checkGet('announcements')
-                            or ubRouting::checkGet('tickets')
-                            or ubRouting::checkGet('opayz')
-                            or ubRouting::checkGet('agentassigned')
-                            or ubRouting::checkGet('tariffvservices')
-                            or ubRouting::checkGet('feecharges')
-                            or ubRouting::checkGet('ticketcreate')
-                           );
+        $getUserData    = !(ubRouting::checkGet(array(
+                                    'payments',
+                                    'announcements',
+                                    'tickets',
+                                    'opayz',
+                                    'agentassigned',
+                                    'tariffvservices',
+                                    'feecharges',
+                                    'ticketcreate'
+                                    ),
+                                true, true)
+                            );
 
         if (!empty($user_login)) {
             if ($getUserData) {

--- a/userstats/modules/engine/api.xmlagent.php
+++ b/userstats/modules/engine/api.xmlagent.php
@@ -223,8 +223,8 @@ class XMLAgent {
                     $resultToRender = $this->getUserFeeCharges($user_login, $date_from, $date_to);
                 }
 
-                if (ubRouting::checkGet('ticketcreate') and ubRouting::checkGet('tickettext')
-                    and ubRouting::checkGet('tickettype') and ubRouting::get('tickettype') == self::TICKET_TYPE_SUPPORT
+                if (ubRouting::checkGet(array('ticketcreate', 'tickettext', 'tickettype'))
+                    and ubRouting::get('tickettype') == self::TICKET_TYPE_SUPPORT
                 ) {
                     $text           = base64_decode(ubRouting::get('tickettext'));
                     $debugData      = $text;
@@ -245,7 +245,7 @@ class XMLAgent {
             $resultToRender = $this->getAllTariffsVservices();
         }
 
-        if (ubRouting::checkGet('ticketcreate') and ubRouting::checkGet('tickettype')
+        if (ubRouting::checkGet(array('ticketcreate', 'tickettype'))
             and ubRouting::get('tickettype') == self::TICKET_TYPE_SIGNUP
         ) {
             $requestJSON = file_get_contents("php://input");

--- a/userstats/modules/engine/api.xmlagent.php
+++ b/userstats/modules/engine/api.xmlagent.php
@@ -178,6 +178,7 @@ class XMLAgent {
                                     'opayz',
                                     'agentassigned',
                                     'tariffvservices',
+                                    'activetariffsvservices',
                                     'feecharges',
                                     'ticketcreate'
                                     ),


### PR DESCRIPTION
UbRouting:
&nbsp;&nbsp;&nbsp;Added ability for "checkGet()" and "checkPost()" methods to return "true" when the very first existent GET/POST param encountered. Respecting the $ignoreEmpty parameter though.