### PR TITLE
Fix decbin funtion on php 8.2

### DIFF
--- a/api/libs/api.ponzte.php
+++ b/api/libs/api.ponzte.php
@@ -486,7 +486,7 @@ class PonZte {
     protected function gponOltInterfaceDecode($dec) {
         $result = '';
         $match = array();
-        $binary = decbin($dec);
+        $binary = decbin((int) $dec);
         if (strlen($binary) == 29) {
             preg_match("/(\d{4})(\d{6})(\d{3})(\d{8})(\d{8})/", $binary, $match);
             foreach ($match as &$each) {
@@ -682,7 +682,7 @@ class PonZte {
      * @return string
      */
     protected function interfaceDecode($uuid) {
-        $binary = decbin($uuid);
+        $binary = decbin((int) $uuid);
         $match = $this->getDecodeType($binary);
 
         if (!empty($match) and isset($match[self::DESC_PONTYPE])) {
@@ -967,12 +967,12 @@ class PonZte {
                         // c025.2fac.ff3c   3701   Dynamic   vport-1/3/1.5:1
                         $interfaceVport =  str_replace('gpon-onu_', 'vport-', $this->gponOltInterfaceDecode($vportIndex));
                         $interfaceVport =  str_replace(':', '.', $interfaceVport);
-                        $interfaceVportDecode = $this->getDecodeTypeC6XX(decbin($devIndex));
+                        $interfaceVportDecode = $this->getDecodeTypeC6XX(decbin((int) $devIndex));
                         $interfaceName = $interfaceVport . $interfaceVportDecode[3] . ':' . $interfaceVportDecode[4];
-                        $interfaceVportDecode = $this->getDecodeTypeC6XX(decbin($devIndex));
+                        $interfaceVportDecode = $this->getDecodeTypeC6XX(decbin((int) $devIndex));
                         $interfaceName = $interfaceVport . $interfaceVportDecode[3] . ':' . $interfaceVportDecode[4];
                         */
-                        $interfaceVportDecode = $this->getDecodeTypeC6XX(decbin($devIndex));
+                        $interfaceVportDecode = $this->getDecodeTypeC6XX(decbin((int) $devIndex));
                         $interfaceName = $interfaceVport . $interfaceVportDecode[2];
                         if ($interfaceName) {
                             if (isset($decParts[0])) {


### PR DESCRIPTION
```
[Mon Jul 08 21:30:07.279999 2024] [proxy_fcgi:error] [pid 22000:tid 35443122176] [client 127.0.0.1:49989] AH01071: Got error '; PHP message: PHP Fatal error:  Uncaught TypeError: decbin(): Argument #1 ($num) must be of type int, string given in /var/www/billing/api/libs/api.ponzte.php:975\nStack trace:\n#0 /var/www/billing/api/libs/api.ponzte.php(975): decbin('')\n#1 /var/www/billing/api/libs/api.ponzte.php(1232): PonZte->fdbParseGpon()\n#2 /var/www/billing/api/libs/api.ponztegpon.php(14): PonZte->pollGpon()\n#3 /var/www/billing/api/libs/api.ponizer.php(903): PONZteGpon->collect()\n#4 /var/www/billing/modules/remoteapi/herd.php(30): PONizer->pollOltSignal('1')\n#5 /var/www/billing/modules/general/remoteapi/index.php(37): require_once('/var/www/billin...')\n#6 /var/www/billing/index.php(133): include_once('/var/www/billin...')\n#7 {main}\n  thrown in /var/www/billing/api/libs/api.ponzte.php on line 975'
```

## Description
_Describe the problem or feature_

