### PR TITLE
xmlagent_getuserfeecharges_fix

### DIFF
--- a/userstats/modules/engine/api.userstats.php
+++ b/userstats/modules/engine/api.userstats.php
@@ -1410,9 +1410,10 @@ function zbs_VservicesGetAllNamesLabeled() {
     $result = array();
     $allservices = zbs_getVservicesAll();
     $alltagnames = zbs_getTagNames();
+
     if (!empty($allservices)) {
-        foreach ($allservices as $io => $eachservice) {
-            @$result['Service:' . $eachservice['id']] = $alltagnames[$eachservice['tagid']];
+        foreach ($allservices as $eachTagID => $eachPrice) {
+            $result['Service:' . $eachTagID] = $alltagnames[$eachTagID];
         }
     }
 

--- a/userstats/modules/engine/api.xmlagent.php
+++ b/userstats/modules/engine/api.xmlagent.php
@@ -1127,7 +1127,7 @@ class XMLAgent {
      */
     protected function createSupportTicket($login, $tickettext, $replyID) {
         $ticketID = 0;
-        $replyID  = empty($replyID) ? 'NULL' : $replyID;
+        $replyID  = empty($replyID) ? NULL : $replyID;
         $result   = array();
 
         if (!empty($login) and !empty($tickettext)) {
@@ -1136,6 +1136,7 @@ class XMLAgent {
             $date = curdatetime();
 
             $ticketDB = new NyanORM('ticketing');
+$ticketDB->setDebug(true, true);
             $ticketDB->dataArr(array(
                                 'date'    => $date,
                                 'replyid' => $replyID,

--- a/userstats/modules/engine/api.xmlagent.php
+++ b/userstats/modules/engine/api.xmlagent.php
@@ -1127,7 +1127,7 @@ class XMLAgent {
      */
     protected function createSupportTicket($login, $tickettext, $replyID) {
         $ticketID = 0;
-        $replyID  = empty($replyID) ? NULL : $replyID;
+        $replyID  = empty($replyID) ? 'NULL' : $replyID;
         $result   = array();
 
         if (!empty($login) and !empty($tickettext)) {
@@ -1136,14 +1136,17 @@ class XMLAgent {
             $date = curdatetime();
 
             $ticketDB = new NyanORM('ticketing');
-$ticketDB->setDebug(true, true);
             $ticketDB->dataArr(array(
-                                'date'    => $date,
-                                'replyid' => $replyID,
+                                'date'    => $date,                                
                                 'status'  => '0',
                                 'from'    => $from,
                                 'text'    => $text
                                ));
+            
+            if (!empty($replyID) and $replyID != 'NULL') {
+                $ticketDB->data('replyid', $replyID);
+            }
+
             $ticketDB->create();
             $ticketID = $ticketDB->getLastId();
         }


### PR DESCRIPTION
XMLAgent:
&nbsp;&nbsp;&nbsp;&nbsp;fixed the fatal defect with "getUserFeeCharges()" call, which was totally messed up because of thoughtless copypasting and hided behind simple "Illegal index offset" warning on PHP versions prior to 8.x.x, where that became a strict ERROR and revealed the issue.