### PR TITLE
Ponstels16_major_update_retry

### DIFF
--- a/config/snmptemplates/STELS_FD16XXS_gpon
+++ b/config/snmptemplates/STELS_FD16XXS_gpon
@@ -8,6 +8,9 @@ DEVICE="STELS_FD16XXS"
 SIGNALMODE="HAL"
 COLLECTORNAME="PONStels16"
 
+;Can be "bulk" or "single". With "single" poll type ONU Rx signals will be queried individually, on a per-ONU basis(yeah, many-many SNMP requests). Default - "bulk".
+;SIGNAL_POLL_TYPE="bulk"
+
 SIGINDEX=".1.3.6.1.4.1.17409.2.3.3.6.1.2" 
 MACINDEX=".1.3.6.1.4.1.17409.2.8.4.1.1.3"
 SIGVALUE="INTEGER:"

--- a/config/snmptemplates/STELS_FD16XXS_gpon_v1
+++ b/config/snmptemplates/STELS_FD16XXS_gpon_v1
@@ -8,6 +8,9 @@ DEVICE="STELS_FD16XXS_v1"
 SIGNALMODE="HAL"
 COLLECTORNAME="PONStels16"
 
+;Can be "bulk" or "single". With "single" poll type ONU Rx signals will be queried individually, on a per-ONU basis(yeah, many-many SNMP requests). Default - "bulk".
+;SIGNAL_POLL_TYPE="bulk"
+
 SIGINDEX=".1.3.6.1.4.1.17409.2.8.4.4.1.4"
 MACINDEX=".1.3.6.1.4.1.17409.2.8.4.1.1.3"
 SIGVALUE="INTEGER:"


### PR DESCRIPTION
PONizer:
&nbsp;&nbsp;&nbsp;&nbsp;Implemented individual signal polling on a per-ONU basis.
&nbsp;&nbsp;&nbsp;&nbsp;Updated SNMP templates for this OLTs model with a new option to provide possibility to control the signal polling mode.
&nbsp;&nbsp;&nbsp;&nbsp;Refactored "signalParse()" method to avoid the processing of the "macIndex" array twice(that might make the polling process slightly faster in "bulk" mode).