### PR TITLE
Update api.dhcppl.php for parsing MAC in right way

### DIFF
--- a/api/libs/api.dhcppl.php
+++ b/api/libs/api.dhcppl.php
@@ -167,7 +167,7 @@ class DHCPPL {
     protected function setOptions($userLogin = '', $userIp = '', $userMac = '') {
         $this->userLogin = $userLogin;
         $this->userIp = $userIp;
-        $this->userMac = $userMac;
+        $this->userMac = strtolower($userMac); // Set MAC to lower case
     }
 
     /**
@@ -203,8 +203,10 @@ class DHCPPL {
             $macParse = $this->userMac;
             $grepPath = $this->grep;
             if ($this->opt82Flag) {
-                $grepPath = $this->grep . ' -E';
+                $grepPath = $this->grep . ' -E -i'; // Add -i flag for case insensitive search
                 $macParse = '"( ' . $this->userIp . '(:)? )|(' . $this->userMac . ')"';
+            } else {
+            $grepPath = $this->grep . ' -i'; // Add -i flag for normal search
             }
             $command = $this->sudo . ' ' . $this->cat . ' ' . $this->logPath . ' | ' . $grepPath . ' ' . $macParse . ' | ' . $this->tail . '  -n ' . $this->linesRender;
             $result = shell_exec($command);


### PR DESCRIPTION
Add the possibility to parse MAC addresses correctly if it stored in the DB in a different letter case than in the DHCP-log file.

## Description
Коли МАС адреси в БД були збережені в нижньому регістрі (aa:bb:cc:dd:ee:ff) а в логах DHCP вони зберігаються в верхньому регістрі (AA:BB:CC:DD:EE:FF) то в картці абонента не відображається історія видачі айпі-адрес і поточний статус DHCP.


###
Please, don't push the horses. Could you add these small corrections to the main branch so that I will have no further fixes to make with every update?