### PR TITLE
Displaying amounts payments in the user's personal account

### DIFF
--- a/userstats/modules/general/payments/index.php
+++ b/userstats/modules/general/payments/index.php
@@ -25,8 +25,13 @@ function zbs_ShowUserPayments($login) {
                 }
 
                 $cells = la_TableCell($dateCells);
-                $cells .= la_TableCell($eachpayment['summ']);
-                $cells .= la_TableCell($eachpayment['balance']);
+                if (isset($usConfig['PAYMENTS_ROUND_SUMM']) AND $usConfig['PAYMENTS_ROUND_SUMM']) {
+                    $cells .= la_TableCell(web_roundValue($eachpayment['summ'], 2));
+                    $cells .= la_TableCell(web_roundValue($eachpayment['balance'], 2));
+                } else {
+                    $cells .= la_TableCell($eachpayment['summ']);
+                    $cells .= la_TableCell($eachpayment['balance']);
+                }
                 $rows .= la_TableRow($cells, 'row2');
             }
         }


### PR DESCRIPTION

## Displaying amounts payments in the user's personal account
Added a new optional option:
```PAYMENTS_ROUND_SUMM```
, which rounds withdrawal amounts and user balance to hundredths


