### PR TITLE
Fix variable name for svlan check in vlanmanagement

### DIFF
--- a/api/libs/api.vlanmanagement.php
+++ b/api/libs/api.vlanmanagement.php
@@ -1747,7 +1747,7 @@ class VlanManagement {
                     $svlan_id = $allSwitchQinq[$switchId]['svlan_id'];
                     $this->svlanDb->where('id', '=', $svlan_id);
                     $svlans = $this->svlanDb->getAll('id');
-                    if (isset($svlan[$svlan_id])) {
+                    if (isset($svlans[$svlan_id])) {
                         $svlan = $svlans[$svlan_id]['svlan'];
                         $cvlan = $startCvlan + $port;
                     }


### PR DESCRIPTION
Баг живе мінімум з 1.2.0 rev 8092. Через опечатку в карточці клієнта не показує пара пул sVlan/cVlan.

## Description
_Describe the problem or feature_

